### PR TITLE
Adding PreferredChain options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,8 @@ indent_size = 2
 
 # C# files
 [*.cs]
+charset = utf-8-bom
+
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/KeyVault.Acmebot/GetCertificatesFunctions.cs
+++ b/KeyVault.Acmebot/GetCertificatesFunctions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/KeyVault.Acmebot/GetDnsZonesFunctions.cs
+++ b/KeyVault.Acmebot/GetDnsZonesFunctions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/KeyVault.Acmebot/Internal/AccountKey.cs
+++ b/KeyVault.Acmebot/Internal/AccountKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using ACMESharp.Crypto.JOSE;
 

--- a/KeyVault.Acmebot/Internal/AcmeProtocolClientExtensions.cs
+++ b/KeyVault.Acmebot/Internal/AcmeProtocolClientExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ACMESharp.Protocol;
+
+namespace KeyVault.Acmebot.Internal
+{
+    internal static class AcmeProtocolClientExtensions
+    {
+        public static async Task<X509Certificate2Collection> GetOrderCertificateAsync(this AcmeProtocolClient acmeProtocolClient, OrderDetails order,
+                                                                                      string preferredChain = null, CancellationToken cancel = default)
+        {
+            IEnumerable<string> linkHeaders;
+            X509Certificate2Collection defaultX509Certificates;
+
+            using (var resp = await acmeProtocolClient.GetAsync(order.Payload.Certificate, cancel))
+            {
+                defaultX509Certificates = await resp.Content.ReadAsCertificatesAsync();
+
+                // 証明書チェーンが未指定、もしくはデフォルトのチェーンの場合は即返す
+                if (preferredChain == null || defaultX509Certificates.Find(X509FindType.FindByIssuerName, preferredChain, true).Count > 0)
+                {
+                    return defaultX509Certificates;
+                }
+
+                linkHeaders = resp.Headers.GetValues("Link");
+            }
+
+            foreach (var linkHeader in linkHeaders)
+            {
+                // Link ヘッダーから alternate で指定されている URL を拾ってくる
+                var rel = Regex.Match(linkHeader, "(?<=rel=\").+?(?=\")", RegexOptions.IgnoreCase);
+
+                if (!string.Equals(rel.Value, "alternate", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var url = Regex.Match(linkHeader, "(?<=<).+?(?=>)", RegexOptions.IgnoreCase);
+
+                // 代替の証明書をダウンロードする
+                using (var resp = await acmeProtocolClient.GetAsync(url.Value, cancel))
+                {
+                    var x509Certificates = await resp.Content.ReadAsCertificatesAsync();
+
+                    // 指定された証明書チェーンに一致する場合は返す
+                    if (x509Certificates.Find(X509FindType.FindByIssuerName, preferredChain, true).Count > 0)
+                    {
+                        return x509Certificates;
+                    }
+                }
+            }
+
+            // マッチする証明書チェーンが存在しない場合はデフォルトを返す
+            return defaultX509Certificates;
+        }
+    }
+}

--- a/KeyVault.Acmebot/Internal/X509Certificate2Extensions.cs
+++ b/KeyVault.Acmebot/Internal/X509Certificate2Extensions.cs
@@ -1,5 +1,7 @@
-using System;
+﻿using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace KeyVault.Acmebot.Internal
 {
@@ -29,6 +31,17 @@ namespace KeyVault.Acmebot.Internal
 
                 rawDataSpan = rawDataSpan.Slice(foundIndex + EndCertificate.Length);
             }
+        }
+
+        public static async Task<X509Certificate2Collection> ReadAsCertificatesAsync(this HttpContent httpContent)
+        {
+            var certificateData = await httpContent.ReadAsByteArrayAsync();
+
+            var x509Certificates = new X509Certificate2Collection();
+
+            x509Certificates.ImportFromPem(certificateData);
+
+            return x509Certificates;
         }
     }
 }

--- a/KeyVault.Acmebot/Options/AcmebotOptions.cs
+++ b/KeyVault.Acmebot/Options/AcmebotOptions.cs
@@ -22,6 +22,8 @@ namespace KeyVault.Acmebot.Options
         [Required]
         public string Environment { get; set; } = "AzureCloud";
 
+        public string PreferredChain { get; set; }
+
         public AzureDnsOptions AzureDns { get; set; }
 
         public CloudflareOptions Cloudflare { get; set; }

--- a/KeyVault.Acmebot/PurgeInstanceHistoryFunctions.cs
+++ b/KeyVault.Acmebot/PurgeInstanceHistoryFunctions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 using DurableTask.Core;

--- a/KeyVault.Acmebot/SharedFunctions.cs
+++ b/KeyVault.Acmebot/SharedFunctions.cs
@@ -331,17 +331,12 @@ namespace KeyVault.Acmebot
 
             var finalize = await acmeProtocolClient.FinalizeOrderAsync(orderDetails.Payload.Finalize, csr);
 
-            // 証明書をバイト配列としてダウンロード
-            var certificateData = await acmeProtocolClient.GetOrderCertificateAsync(finalize);
-
-            // X509Certificate2Collection を作成
-            var x509Certificates = new X509Certificate2Collection();
-
-            x509Certificates.ImportFromPem(certificateData);
+            // 証明書をダウンロード
+            var x509Certificates = await acmeProtocolClient.GetOrderCertificateAsync(finalize, _options.PreferredChain);
 
             var mergeCertificateOptions = new MergeCertificateOptions(
                 certificateName,
-                x509Certificates.OfType<X509Certificate2>().Select(x => x.Export(X509ContentType.Pfx))
+                x509Certificates.Cast<X509Certificate2>().Select(x => x.Export(X509ContentType.Pfx))
             );
 
             return (await _certificateClient.MergeCertificateAsync(mergeCertificateOptions)).Value.ToCertificateItem();

--- a/KeyVault.Acmebot/Startup.cs
+++ b/KeyVault.Acmebot/Startup.cs
@@ -90,7 +90,15 @@ namespace KeyVault.Acmebot
 
             builder.Services.AddOptions<AcmebotOptions>()
                    .Bind(section.Exists() ? section : context.Configuration.GetSection("LetsEncrypt"))
-                   .ValidateDataAnnotations();
+                   .ValidateDataAnnotations()
+                   .PostConfigure(options =>
+                   {
+                       // Backward compatibility
+                       if (options.Endpoint == "https://acme-v02.api.letsencrypt.org/")
+                       {
+                           options.PreferredChain ??= "DST Root CA X3";
+                       }
+                   });
         }
     }
 }

--- a/KeyVault.Acmebot/StaticPageFunctions.cs
+++ b/KeyVault.Acmebot/StaticPageFunctions.cs
@@ -1,4 +1,4 @@
-using Azure.WebJobs.Extensions.HttpApi;
+﻿using Azure.WebJobs.Extensions.HttpApi;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;


### PR DESCRIPTION

- Adding `Acmebot:PreferredChain` option
  - `DST Root CA X3` (default, backward compatibility after 2020/9/30)
  - `ISRG Root X1` (future default)

https://community.letsencrypt.org/t/workflow-for-using-alternate-link-relation/129321