### PR TITLE
Support API key authorization for static page

### DIFF
--- a/KeyVault.Acmebot/static/add-certificate.html
+++ b/KeyVault.Acmebot/static/add-certificate.html
@@ -85,6 +85,15 @@
       return new Promise(resolve => setTimeout(() => resolve(), millisecondsDelay));
     }
 
+    const code = new URL(location.href).searchParams.get("code") || undefined;
+    axios.interceptors.request.use((config) => {
+      if(code){
+        config.params = config.params || {};
+        config.params['code'] = code;
+      }
+      return config;
+    });
+
     Vue.filter("punycode", function (value) {
       return punycode.toUnicode(value);
     });

--- a/KeyVault.Acmebot/static/renew-certificate.html
+++ b/KeyVault.Acmebot/static/renew-certificate.html
@@ -76,6 +76,15 @@
       return new Promise(resolve => setTimeout(() => resolve(), millisecondsDelay));
     }
 
+    const code = new URL(location.href).searchParams.get("code") || undefined;
+    axios.interceptors.request.use((config) => {
+      if(code){
+        config.params = config.params || {};
+        config.params['code'] = code;
+      }
+      return config;
+    });
+
     Vue.filter("punycode", function (value) {
       return punycode.toUnicode(value);
     });


### PR DESCRIPTION
If I use API Key authentication instead of App Service authentication, I get the following error when accessing the web page.

![image](https://user-images.githubusercontent.com/3121624/94373626-9ccb4000-0141-11eb-9224-6c70e5b17aff.png)

This is cause by a missing `code` parameter in the API request.
So, I added support for filling in the `code` parameter from the `location.href`.

I think it's useful that only people who know the API Key can use it. This change is no effect on AppService Authentication.
But, regressive to AppService Authentication, it may be a bad idea.

