### PR TITLE
Google Cloud DNS

### DIFF
--- a/KeyVault.Acmebot/KeyVault.Acmebot.csproj
+++ b/KeyVault.Acmebot/KeyVault.Acmebot.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.1.0" />
     <PackageReference Include="DnsClient" Version="1.3.2" />
     <PackageReference Include="DurableTask.TypedProxy" Version="2.1.0" />
-    <PackageReference Include="Google.Apis.Dns.v1" Version="1.49.0.2096" />
+    <PackageReference Include="Google.Apis.Dns.v1" Version="1.49.0.2112" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.3.0" />

--- a/KeyVault.Acmebot/KeyVault.Acmebot.csproj
+++ b/KeyVault.Acmebot/KeyVault.Acmebot.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.1.0" />
     <PackageReference Include="DnsClient" Version="1.3.2" />
     <PackageReference Include="DurableTask.TypedProxy" Version="2.1.0" />
+    <PackageReference Include="Google.Apis.Dns.v1" Version="1.49.0.2096" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.3.0" />

--- a/KeyVault.Acmebot/Options/AcmebotOptions.cs
+++ b/KeyVault.Acmebot/Options/AcmebotOptions.cs
@@ -28,6 +28,8 @@ namespace KeyVault.Acmebot.Options
 
         public CloudflareOptions Cloudflare { get; set; }
 
+        public GoogleDnsOptions Google { get; set; }
+
         public GratisDnsOptions GratisDns { get; set; }
     }
 }

--- a/KeyVault.Acmebot/Options/GoogleDnsOptions .cs
+++ b/KeyVault.Acmebot/Options/GoogleDnsOptions .cs
@@ -1,0 +1,7 @@
+﻿namespace KeyVault.Acmebot.Options
+{
+    public class GoogleDnsOptions
+    {
+        public string KeyFile64 { get; set; }
+    }
+}

--- a/KeyVault.Acmebot/Providers/GoogleDnsProvider.cs
+++ b/KeyVault.Acmebot/Providers/GoogleDnsProvider.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Dns.v1;
+using Google.Apis.Dns.v1.Data;
+using Google.Apis.Json;
+using Google.Apis.Services;
+using KeyVault.Acmebot.Options;
+
+namespace KeyVault.Acmebot.Providers
+{
+    public class GoogleDnsProvider : IDnsProvider
+    {
+        public GoogleDnsProvider(GoogleDnsOptions options)
+        {
+            string jsonString = Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64));
+            _credsParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(jsonString);
+            var credential = GoogleCredential.FromJson(jsonString).CreateScoped(DnsService.Scope.NdevClouddnsReadwrite);
+
+            // Create the service.
+            _dnsService = new DnsService(new BaseClientService.Initializer {HttpClientInitializer = credential});
+        }
+
+        private readonly DnsService _dnsService;
+        private readonly JsonCredentialParameters _credsParameters;
+
+
+        public int PropagationSeconds => 10;
+
+        public async Task<IReadOnlyList<DnsZone>> ListZonesAsync()
+        {
+            var zones = await _dnsService.ManagedZones.List(_credsParameters.ProjectId).ExecuteAsync();
+
+            return zones.ManagedZones
+                .Select(managedZone => new DnsZone {Id = managedZone.Id.ToString(), Name = managedZone.DnsName})
+                .ToArray();
+        }
+
+        public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values)
+        {
+            string recordName = $"{relativeRecordName}.{zone.Name}";
+            var change = new Change()
+            {
+                Additions = new List<ResourceRecordSet>
+                {
+                    new ResourceRecordSet
+                    {
+                        Kind = "dns#resourceRecordSet",
+                        Type = "TXT",
+                        Ttl = 60,
+                        Rrdatas = values.ToArray(),
+                        Name = recordName
+                    }
+                }
+            };
+
+            await _dnsService.Changes.Create(change, _credsParameters.ProjectId, zone.Id).ExecuteAsync();
+        }
+
+        public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName)
+        {
+            string recordName = $"{relativeRecordName}.{zone.Name}";
+            var txtRecords = await
+                new ResourceRecordSetsResource.ListRequest(_dnsService, _credsParameters.ProjectId, zone.Id)
+                {
+                    Name = recordName, Type = "TXT"
+                }.ExecuteAsync();
+            if (txtRecords.Rrsets.Count == 0)
+            {
+                return;
+            }
+
+            var change = new Change {Deletions = txtRecords.Rrsets};
+            await _dnsService.Changes.Create(change, _credsParameters.ProjectId, zone.Id).ExecuteAsync();
+        }
+    }
+}

--- a/KeyVault.Acmebot/Providers/GoogleDnsProvider.cs
+++ b/KeyVault.Acmebot/Providers/GoogleDnsProvider.cs
@@ -21,7 +21,7 @@ namespace KeyVault.Acmebot.Providers
             var credential = GoogleCredential.FromJson(jsonString).CreateScoped(DnsService.Scope.NdevClouddnsReadwrite);
 
             // Create the service.
-            _dnsService = new DnsService(new BaseClientService.Initializer {HttpClientInitializer = credential});
+            _dnsService = new DnsService(new BaseClientService.Initializer { HttpClientInitializer = credential });
         }
 
         private readonly DnsService _dnsService;
@@ -35,7 +35,7 @@ namespace KeyVault.Acmebot.Providers
             var zones = await _dnsService.ManagedZones.List(_credsParameters.ProjectId).ExecuteAsync();
 
             return zones.ManagedZones
-                .Select(managedZone => new DnsZone {Id = managedZone.Id.ToString(), Name = managedZone.DnsName})
+                .Select(managedZone => new DnsZone { Id = managedZone.Id.ToString(), Name = managedZone.DnsName })
                 .ToArray();
         }
 
@@ -66,14 +66,15 @@ namespace KeyVault.Acmebot.Providers
             var txtRecords = await
                 new ResourceRecordSetsResource.ListRequest(_dnsService, _credsParameters.ProjectId, zone.Id)
                 {
-                    Name = recordName, Type = "TXT"
+                    Name = recordName,
+                    Type = "TXT"
                 }.ExecuteAsync();
             if (txtRecords.Rrsets.Count == 0)
             {
                 return;
             }
 
-            var change = new Change {Deletions = txtRecords.Rrsets};
+            var change = new Change { Deletions = txtRecords.Rrsets };
             await _dnsService.Changes.Create(change, _credsParameters.ProjectId, zone.Id).ExecuteAsync();
         }
     }

--- a/KeyVault.Acmebot/Startup.cs
+++ b/KeyVault.Acmebot/Startup.cs
@@ -88,6 +88,11 @@ namespace KeyVault.Acmebot
                     return new CloudflareProvider(options.Cloudflare);
                 }
 
+                if (options.Google != null)
+                {
+                    return new GoogleDnsProvider(options.Google);
+                }
+
                 if (options.GratisDns != null)
                 {
                     return new GratisDnsProvider(options.GratisDns);

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You will need the following:
   - Azure DNS
   - Cloudflare
   - GratisDNS
+  - Google Cloud DNS
 - Email address (required to register with ACME)
 
 ## Getting Started
@@ -102,7 +103,7 @@ There are also additional settings that will be automatically created by Key Vau
   - The email address (required) used in ACME account registration
 - Acmebot:AzureDns:SubscriptionId
   - Your Azure subscription ID in order to identify which DNS resources can be used for ACME
-  
+
 ### 3. Enable App Service Authentication
 
 You must enable Authentication on the Function App that is deployed as part of this application.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ You will need the following:
 - DNS provider (required to host your public DNS zone)
   - Azure DNS
   - Cloudflare
-  - GratisDNS
   - Google Cloud DNS
+  - GratisDNS
 - Email address (required to register with ACME)
 
 ## Getting Started


### PR DESCRIPTION
I have added support for Google Cloud DNS. 

To use cloud DNS : 
1. Create a service account for your project with DNS readwrite access.
"https://www.googleapis.com/auth/ndev.clouddns.readwrite"
2. Generate and download a json keyfile.
3. Take keyfile contents and encode them in base64
4. Create a new application setting named `Acmebot:Google:KeyFile64` and paste the base64 encoded string into it.