### PR TITLE
(feat) Renew certificates by handling Azure Key Vault events rather than Timer Trigger

### DIFF
--- a/KeyVault.Acmebot/Functions/ISharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/ISharedActivity.cs
@@ -12,6 +12,8 @@ namespace KeyVault.Acmebot.Functions
 {
     public interface ISharedActivity
     {
+        Task<CertificateItem> GetExpiringCertificate(string certificateName);
+
         Task<IReadOnlyList<CertificateItem>> GetExpiringCertificates(DateTime currentDateTime);
 
         Task<IReadOnlyList<CertificateItem>> GetAllCertificates(object input = null);

--- a/KeyVault.Acmebot/Functions/RenewCertificate.cs
+++ b/KeyVault.Acmebot/Functions/RenewCertificate.cs
@@ -50,7 +50,7 @@ namespace KeyVault.Acmebot.Functions
         }
 
         [FunctionName(nameof(RenewCertificate) + "_" + nameof(EventGrid))]
-        public async Task EventGrid([EventGridTrigger]EventGridEvent eventGridEvent, [DurableClient] IDurableClient starter, ILogger log)
+        public async Task EventGrid([EventGridTrigger] EventGridEvent eventGridEvent, [DurableClient] IDurableClient starter, ILogger log)
         {
             if (eventGridEvent.EventType.Equals("Microsoft.KeyVault.CertificateNearExpiry", StringComparison.OrdinalIgnoreCase))
             {

--- a/KeyVault.Acmebot/Functions/RenewCertificate.cs
+++ b/KeyVault.Acmebot/Functions/RenewCertificate.cs
@@ -1,0 +1,74 @@
+﻿// Default URL for triggering event grid function in the local environment.
+// http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
+using System;
+using System.Threading.Tasks;
+
+using DurableTask.TypedProxy;
+
+using Microsoft.Azure.EventGrid.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+using Microsoft.Extensions.Logging;
+
+using Newtonsoft.Json.Linq;
+
+namespace KeyVault.Acmebot.Functions
+{
+    public class RenewCertificate
+    {
+        [FunctionName(nameof(RenewCertificate) + "_" + nameof(Orchestrator))]
+        public async Task Orchestrator([OrchestrationTrigger] IDurableOrchestrationContext context, ILogger log)
+        {
+            var activity = context.CreateActivityProxy<ISharedActivity>();
+
+            var certificateName = context.GetInput<string>();
+            var certificate = await activity.GetExpiringCertificate(certificateName);
+
+            if (certificate == null)
+            {
+                log.LogInformation("Certificate was not found");
+
+                return;
+            }
+
+            var dnsNames = certificate.DnsNames;
+
+            log.LogInformation($"{certificate.Id} - {certificate.ExpiresOn}");
+
+            try
+            {
+                // 証明書の更新処理を開始
+                await context.CallSubOrchestratorAsync(nameof(SharedOrchestrator.IssueCertificate), dnsNames);
+            }
+            catch (Exception ex)
+            {
+                // 失敗した場合はログに詳細を書き出して続きを実行する
+                log.LogError($"Failed sub orchestration with DNS names = {string.Join(",", dnsNames)}");
+                log.LogError(ex.Message);
+            }
+        }
+
+        [FunctionName(nameof(RenewCertificate) + "_" + nameof(EventGrid))]
+        public async Task EventGrid([EventGridTrigger]EventGridEvent eventGridEvent, [DurableClient] IDurableClient starter, ILogger log)
+        {
+            if (eventGridEvent.EventType.Equals("Microsoft.KeyVault.CertificateNearExpiry", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var data = (JObject)eventGridEvent.Data;
+                    var certificateName = data.Value<string>("objectName");
+
+                    var instanceId = await starter.StartNewAsync<string>(nameof(RenewCertificate) + "_" + nameof(Orchestrator), certificateName);
+
+                    log.LogInformation($"Started orchestration with ID = '{instanceId}'.");
+                }
+                catch (Exception ex)
+                {
+                    log.LogError($"Unable to start orchestration due to possible malformed event. Event Id: {eventGridEvent.Id}");
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -65,6 +65,7 @@ namespace KeyVault.Acmebot.Functions
         public async Task<IReadOnlyList<CertificateItem>> GetExpiringCertificates([ActivityTrigger] DateTime currentDateTime)
         {
             var certificates = _certificateClient.GetPropertiesOfCertificatesAsync();
+
             var result = new List<CertificateItem>();
 
             await foreach (var certificate in certificates)

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -48,11 +48,24 @@ namespace KeyVault.Acmebot.Functions
 
         private const string IssuerName = "Acmebot";
 
+        [FunctionName(nameof(GetExpiringCertificate))]
+        public async Task<CertificateItem> GetExpiringCertificate([ActivityTrigger] string certificateName)
+        {
+            var certificate = await _certificateClient.GetCertificateAsync(certificateName);
+
+            if (certificate.Value.Properties.TagsFilter(IssuerName, _options.Endpoint))
+            {
+                return certificate.Value.ToCertificateItem();
+            }
+
+            return null;
+        }
+
         [FunctionName(nameof(GetExpiringCertificates))]
         public async Task<IReadOnlyList<CertificateItem>> GetExpiringCertificates([ActivityTrigger] DateTime currentDateTime)
         {
             var certificates = _certificateClient.GetPropertiesOfCertificatesAsync();
-
+            
             var result = new List<CertificateItem>();
 
             await foreach (var certificate in certificates)

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -65,7 +65,6 @@ namespace KeyVault.Acmebot.Functions
         public async Task<IReadOnlyList<CertificateItem>> GetExpiringCertificates([ActivityTrigger] DateTime currentDateTime)
         {
             var certificates = _certificateClient.GetPropertiesOfCertificatesAsync();
-            
             var result = new List<CertificateItem>();
 
             await foreach (var certificate in certificates)

--- a/KeyVault.Acmebot/KeyVault.Acmebot.csproj
+++ b/KeyVault.Acmebot/KeyVault.Acmebot.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Google.Apis.Dns.v1" Version="1.50.0.2226" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.12" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="WebJobs.Extensions.HttpApi" Version="1.1.0" />

--- a/README.md
+++ b/README.md
@@ -148,9 +148,14 @@ If the `Access Control (IAM)` setting is not correct, nothing will be shown in t
 
 ### Renew an existing certificate
 
-All existing ACME certificates are automatically renewed 30 days before their expiration.
+All existing ACME certificates are automatically renewed 30 days before their expiration using one of two options.
 
-The default check timing is 00:00 UTC. If you need to change the time zone, use `WEBSITE_TIME_ZONE` to set the time zone.
+**Option 1 (default)**: A Timer Trigger which runs every day. The default check timing is 00:00 UTC. If you need to change the time zone, use `WEBSITE_TIME_ZONE` to set the time zone.
+
+**Option 2**: Key Vault Event Grid `Microsoft.KeyVault.CertificateNearExpiry` event is handled by this function app to renew the certificate. [Create a Key Vault Event subscription](https://docs.microsoft.com/en-us/azure/key-vault/general/event-grid-logicapps) but choose Azure Function instead of Logic Apps as the target. You'll then want to choose `RenewCertificate_EventGrid` as the target function.
+
+Finally, disable the Timer Trigger by adding the following Configuration Setting to your the function app:
+`"AzureWebJobs.RenewCertificates_Timer.Disabled": "True"`
 
 ### How to use the issued certificate in Azure services
 


### PR DESCRIPTION
PR adds new `RenewCertificate_EventGrid` orchestration trigger which initiates certificate renewal process by handling the `Microsoft.KeyVault.CertificateNearExpiry` Key Vault event.

This is more efficient than enumerating all certificates in a Key Vault once a day; however, the `RenewCertificates_Timer` remains as that is a no-touch option for those that don't want to setup the Event Grid subscription.

README has also been updated to indicate there are two options for certificate renewal.