### PR TITLE
fix Webhooks for Custom O365 Domains

### DIFF
--- a/KeyVault.Acmebot/Internal/WebhookInvoker.cs
+++ b/KeyVault.Acmebot/Internal/WebhookInvoker.cs
@@ -64,7 +64,7 @@ namespace KeyVault.Acmebot.Internal
                     }
                 };
             }
-            else if (_options.Webhook.Contains("office.com"))
+            else if (_options.Webhook.Contains(".office.com"))
             {
                 model = new
                 {
@@ -110,7 +110,7 @@ namespace KeyVault.Acmebot.Internal
                     }
                 };
             }
-            else if (_options.Webhook.Contains("office.com"))
+            else if (_options.Webhook.Contains(".office.com"))
             {
                 model = new
                 {

--- a/KeyVault.Acmebot/Internal/WebhookInvoker.cs
+++ b/KeyVault.Acmebot/Internal/WebhookInvoker.cs
@@ -64,7 +64,7 @@ namespace KeyVault.Acmebot.Internal
                     }
                 };
             }
-            else if (_options.Webhook.Contains("outlook.office.com"))
+            else if (_options.Webhook.Contains("office.com"))
             {
                 model = new
                 {
@@ -110,7 +110,7 @@ namespace KeyVault.Acmebot.Internal
                     }
                 };
             }
-            else if (_options.Webhook.Contains("outlook.office.com"))
+            else if (_options.Webhook.Contains("office.com"))
             {
                 model = new
                 {


### PR DESCRIPTION
A webhook for teams is currently expected to match the following domain:

`https://outlook.office.com`

For a custom O365 Domain the Webhook URL's for Teams will have the following format, which is currently not recognized as a Teams Webhook by keyvault-acmebot:

`https://yourdomain.webhook.office.com`