### PR TITLE
Add support for exportable private key

### DIFF
--- a/KeyVault.Acmebot/Models/CertificateItem.cs
+++ b/KeyVault.Acmebot/Models/CertificateItem.cs
@@ -37,6 +37,9 @@ namespace KeyVault.Acmebot.Models
         [JsonProperty("reuseKey")]
         public bool? ReuseKey { get; set; }
 
+        [JsonProperty("exportable")]
+        public bool? Exportable { get; set; }
+
         [JsonProperty("isManaged")]
         public bool IsManaged { get; set; }
     }

--- a/KeyVault.Acmebot/Models/CertificatePolicyItem.cs
+++ b/KeyVault.Acmebot/Models/CertificatePolicyItem.cs
@@ -16,6 +16,9 @@ namespace KeyVault.Acmebot.Models
         [JsonProperty("dnsNames")]
         public string[] DnsNames { get; set; }
 
+        [JsonProperty("exportable")]
+        public bool? Exportable { get; set; }
+
         [JsonProperty("keyType")]
         [RegularExpression("^(RSA|EC)$")]
         public string KeyType { get; set; }
@@ -41,6 +44,7 @@ namespace KeyVault.Acmebot.Models
 
             var certificatePolicy = new CertificatePolicy(WellKnownIssuerNames.Unknown, subjectAlternativeNames)
             {
+                Exportable = Exportable,
                 KeySize = KeySize,
                 ReuseKey = ReuseKey
             };

--- a/KeyVault.Acmebot/wwwroot/dashboard/index.html
+++ b/KeyVault.Acmebot/wwwroot/dashboard/index.html
@@ -276,6 +276,25 @@
                   </div>
                 </div>
               </div>
+              <div class="field is-horizontal" v-if="add.useAdvancedOptions">
+                <div class="field-label">
+                  <label class="label">Private key is exportable?</label>
+                </div>
+                <div class="field-body">
+                  <div class="field">
+                    <div class="control">
+                      <label class="radio">
+                        <input type="radio" v-model="add.exportable" v-bind:value="true">
+                        Yes
+                      </label>
+                      <label class="radio">
+                        <input type="radio" v-model="add.exportable" v-bind:value="false">
+                        No
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </section>
             <footer class="modal-card-foot is-justify-content-flex-end">
               <button class="button is-primary" @click="addCertificate" :class="{ 'is-loading': add.sending }">Add</button>
@@ -388,6 +407,16 @@
                 </div>
                 <div class="field is-horizontal">
                   <div class="field-label">
+                    <label class="label">Private key is exportable?</label>
+                  </div>
+                  <div class="field-body">
+                    <div class="content">
+                      {{ details.certificate.exportable }}
+                    </div>
+                  </div>
+                </div>
+                <div class="field is-horizontal">
+                  <div class="field-label">
                     <label class="label">Managed by Acmebot?</label>
                   </div>
                   <div class="field-body">
@@ -425,6 +454,7 @@
             zones: [],
             zoneName: "",
             dnsNames: [],
+            exportable: false,
             recordName: "",
             useAdvancedOptions: false,
             certificateName: "",
@@ -509,6 +539,7 @@
           const postData = {
             dnsNames: this.add.dnsNames,
             certificateName: this.add.certificateName,
+            exportable: this.add.exportable,
             keyType: this.add.keyType,
             reuseKey: this.add.reuseKey
           };


### PR DESCRIPTION
Key Vault does not mark the private key of the certificate as exportable by default when generating the certificate, so you can't export the certificate with its private key from Key Vault or the certificate store where it gets synced.

This PR adds support for the `exportable` option in the Key Vault API, which will mark the private key as exportable when generating the certificate before it is signed.

I haven't had a chance to test it just yet, hopefully we will be able to next week.