### PR TITLE
Add support for connecting to multiple azure subscriptions 

### DIFF
--- a/KeyVault.Acmebot/Internal/DnsProvidersExtensions.cs
+++ b/KeyVault.Acmebot/Internal/DnsProvidersExtensions.cs
@@ -23,4 +23,18 @@ internal static class DnsProvidersExtensions
             dnsProviders.Add(factory(options));
         }
     }
+
+    public static void TryAdd<TOption>(this IList<IDnsProvider> dnsProviders, TOption[] options, Func<TOption, IDnsProvider> factory)
+    {
+        if (options is not null)
+        {
+            foreach (var option in options)
+            {
+                if (option is not null)
+                {
+                    dnsProviders.Add(factory(option));
+                }
+            }
+        }
+    }
 }

--- a/KeyVault.Acmebot/Options/AcmebotOptions.cs
+++ b/KeyVault.Acmebot/Options/AcmebotOptions.cs
@@ -30,7 +30,7 @@ public class AcmebotOptions
     public ExternalAccountBindingOptions ExternalAccountBinding { get; set; }
 
     // Properties should be in alphabetical order
-    public AzureDnsOptions AzureDns { get; set; }
+    public AzureDnsOptions[] AzureDns { get; set; }
 
     public AzurePrivateDnsOptions AzurePrivateDns { get; set; }
 


### PR DESCRIPTION
Hi,

Thanks for creating this useful app.

The changes in this PR allows us to run only one instance of Acmebot for all our Azure subscriptions.
This addresses the common scenarios of having different subscriptions in Azure responsible for different DNS zones. 

This PR helps with the following issues:
https://github.com/shibayan/keyvault-acmebot/issues/295
https://github.com/shibayan/keyvault-acmebot/issues/234


Example app settings configuration:

"Acmebot:AzureDns:0:SubscriptionId": "7746bfbd-55e1-4ea1-9bc7-7da084667b86",
"Acmebot:AzureDns:1:SubscriptionId": "26a3f5f7-0964-406b-ae2d-9da70448aacd",
"Acmebot:AzureDns:2:SubscriptionId": "1ac9cd37-2b05-4d30-a0a1-4c2b5a607a45"



Regards


