### PR TITLE
Handle cases where an authorization is immediately valid

### DIFF
--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -228,7 +228,7 @@ public class SharedActivity : ISharedActivity
             var authorization = await acmeProtocolClient.GetAuthorizationDetailsAsync(authorizationUrl);
 
             // ignore authorizations that are already valid 
-            if (authorization.Status == "valid") 
+            if (authorization.Status == "valid")
             {
                 continue;
             }

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -227,6 +227,12 @@ public class SharedActivity : ISharedActivity
             // Authorization の詳細を取得
             var authorization = await acmeProtocolClient.GetAuthorizationDetailsAsync(authorizationUrl);
 
+            // ignore authorizations that are already valid 
+            if (authorization.Status == "valid") 
+            {
+                continue;
+            }
+
             // DNS-01 Challenge の情報を拾う
             var challenge = authorization.Challenges.FirstOrDefault(x => x.Type == "dns-01");
 


### PR DESCRIPTION
Fixes shibayan/keyvault-acmebot#690

Some CAs support out-of-band domain authorizations, or support ACME pre-authorization.   In these cases an Authorization object may have status=valid immediately when the Order is created.  In these cases no additional processing is needed by the ACME client,