### PR TITLE
Add Entrust to the list of available ACME endpoints

### DIFF
--- a/azuredeploy.bicep
+++ b/azuredeploy.bicep
@@ -14,6 +14,7 @@ param mailAddress string
   'https://api.buypass.com/acme/directory'
   'https://acme.zerossl.com/v2/DV90/'
   'https://dv.acme-v02.api.pki.goog/directory'
+  'https://acme.entrust.net/acme2/directory'
 ])
 param acmeEndpoint string = 'https://acme-v02.api.letsencrypt.org/directory'
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -36,7 +36,8 @@
         "https://acme-v02.api.letsencrypt.org/directory",
         "https://api.buypass.com/acme/directory",
         "https://acme.zerossl.com/v2/DV90/",
-        "https://dv.acme-v02.api.pki.goog/directory"
+        "https://dv.acme-v02.api.pki.goog/directory",
+        "https://acme.entrust.net/acme2/directory"
       ],
       "metadata": {
         "description": "Certification authority ACME Endpoint."

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.26.54.24096",
-      "templateHash": "2201744482523837982"
+      "templateHash": "2724628433207629896"
     }
   },
   "parameters": {


### PR DESCRIPTION
Entrust CA is supported by acmebot.   This update adds the Entrust ACME endpoint to the list of available options.  Fixes shibayan/keyvault-acmebot#697
