### PR TITLE
Increased DNS Made Easy propagation time to 30 seconds

### DIFF
--- a/KeyVault.Acmebot/Providers/DnsMadeEasyProvider.cs
+++ b/KeyVault.Acmebot/Providers/DnsMadeEasyProvider.cs
@@ -27,7 +27,7 @@ public class DnsMadeEasyProvider : IDnsProvider
 
     public string Name => "DNS Made Easy";
 
-    public int PropagationSeconds => 10;
+    public int PropagationSeconds => 30;
 
     public async Task<IReadOnlyList<DnsZone>> ListZonesAsync()
     {


### PR DESCRIPTION
#778 
This is based purely on practical experience, I couldn't find any documentation which would specify what propagation time is expected.

The number piked up also by try and fail. 10 sec didn't work, 15 didn't work, 30 worked. I don't think that it would make any sense to try to pick up minimal working timeout and risk it being fragile.