### PR TITLE
Added support for experimental CNAME record

### DIFF
--- a/KeyVault.Acmebot/Functions/ISharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/ISharedActivity.cs
@@ -24,9 +24,9 @@ public interface ISharedActivity
 
     Task<OrderDetails> Order(IReadOnlyList<string> dnsNames);
 
-    Task<string> Dns01Precondition((string, IReadOnlyList<string>) input);
+    Task<string> Dns01Precondition(CertificatePolicyItem certificatePolicyItem);
 
-    Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization((string, IReadOnlyList<string>) input);
+    Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization((string, string, IReadOnlyList<string>) input);
 
     [RetryOptions("00:00:10", 12, HandlerType = typeof(ExceptionRetryStrategy<RetriableActivityException>))]
     Task CheckDnsChallenge(IReadOnlyList<AcmeChallengeResult> challengeResults);

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -391,7 +391,8 @@ public class SharedActivity : ISharedActivity
             {
                 { "Issuer", "Acmebot" },
                 { "Endpoint", _options.Endpoint.Host },
-                { "DnsProvider", certificatePolicyItem.DnsProviderName }
+                { "DnsProvider", certificatePolicyItem.DnsProviderName },
+                { "DnsAlias", certificatePolicyItem.DnsAlias }
             });
 
             csr = certificateOperation.Properties.Csr;

--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -141,10 +141,8 @@ public class SharedActivity : ISharedActivity
     }
 
     [FunctionName(nameof(Dns01Precondition))]
-    public async Task<string> Dns01Precondition([ActivityTrigger] (string, IReadOnlyList<string>) input)
+    public async Task<string> Dns01Precondition([ActivityTrigger] CertificatePolicyItem certificatePolicyItem)
     {
-        var (dnsProviderName, dnsNames) = input;
-
         // DNS zone の一覧を各 Provider から取得
         var zones = await _dnsProviders.FlattenAllZonesAsync();
 
@@ -152,7 +150,7 @@ public class SharedActivity : ISharedActivity
         var foundZones = new HashSet<DnsZone>();
         var notFoundZoneDnsNames = new List<string>();
 
-        foreach (var dnsName in dnsNames)
+        foreach (var dnsName in certificatePolicyItem.AliasedDnsNames)
         {
             var zone = zones.FindDnsZone(dnsName);
 
@@ -195,7 +193,7 @@ public class SharedActivity : ISharedActivity
         }
 
         // 指定された DNS Provider に属する DNS zone を優先する
-        var dnsProvider = foundZones.Select(x => x.DnsProvider).FirstOrDefault(x => x.Name == dnsProviderName);
+        var dnsProvider = foundZones.Select(x => x.DnsProvider).FirstOrDefault(x => x.Name == certificatePolicyItem.DnsProviderName);
 
         // DNS zone の属する Provider が変わった可能性があるのでフォールバック
         if (dnsProvider is null)
@@ -218,9 +216,9 @@ public class SharedActivity : ISharedActivity
     }
 
     [FunctionName(nameof(Dns01Authorization))]
-    public async Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization([ActivityTrigger] (string, IReadOnlyList<string>) input)
+    public async Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization([ActivityTrigger] (string, string, IReadOnlyList<string>) input)
     {
-        var (dnsProviderName, authorizationUrls) = input;
+        var (dnsProviderName, dnsAlias, authorizationUrls) = input;
 
         var acmeProtocolClient = await _acmeProtocolClientFactory.CreateClientAsync();
 
@@ -251,7 +249,7 @@ public class SharedActivity : ISharedActivity
             challengeResults.Add(new AcmeChallengeResult
             {
                 Url = challenge.Url,
-                DnsRecordName = challengeValidationDetails.DnsRecordName,
+                DnsRecordName = string.IsNullOrEmpty(dnsAlias) ? challengeValidationDetails.DnsRecordName : $"_acme-challenge.{dnsAlias}",
                 DnsRecordValue = challengeValidationDetails.DnsRecordValue
             });
         }

--- a/KeyVault.Acmebot/Internal/CertificateExtensions.cs
+++ b/KeyVault.Acmebot/Internal/CertificateExtensions.cs
@@ -55,13 +55,15 @@ internal static class CertificateExtensions
             KeyType = certificate.Policy.KeyType?.ToString(),
             KeySize = certificate.Policy.KeySize,
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
-            ReuseKey = certificate.Policy.ReuseKey
+            ReuseKey = certificate.Policy.ReuseKey,
+            DnsAlias = certificate.Properties.Tags.TryGetDnsAlias(out var dnsAlias) ? dnsAlias : ""
         };
     }
 
     private const string IssuerKey = "Issuer";
     private const string EndpointKey = "Endpoint";
     private const string DnsProviderKey = "DnsProvider";
+    private const string DnsAliasKey = "DnsAlias";
 
     private const string IssuerValue = "Acmebot";
 
@@ -70,6 +72,9 @@ internal static class CertificateExtensions
     private static bool TryGetEndpoint(this IDictionary<string, string> tags, out string endpoint) => tags.TryGetValue(EndpointKey, out endpoint);
 
     private static bool TryGetDnsProvider(this IDictionary<string, string> tags, out string dnsProviderName) => tags.TryGetValue(DnsProviderKey, out dnsProviderName);
+
+    private static bool TryGetDnsAlias(this IDictionary<string, string> tags, out string dnsAlias) => tags.TryGetValue(DnsAliasKey, out dnsAlias);
+
 
     private static string ToHexString(byte[] bytes)
     {

--- a/KeyVault.Acmebot/Models/CertificatePolicyItem.cs
+++ b/KeyVault.Acmebot/Models/CertificatePolicyItem.cs
@@ -31,6 +31,11 @@ public class CertificatePolicyItem : IValidatableObject
     [JsonProperty("reuseKey")]
     public bool? ReuseKey { get; set; }
 
+    [JsonProperty("dnsAlias")]
+    public string DnsAlias { get; set; }
+
+    public IEnumerable<string> AliasedDnsNames => string.IsNullOrEmpty(DnsAlias) ? DnsNames : new[] { DnsAlias };
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (DnsNames is null || DnsNames.Length == 0)


### PR DESCRIPTION
We have implemented a delegate for the ACME challenge using an experimental CNAME record. At the moment, there is no support for a web UI (because we cannot get a list from the DNS provider).

 If you want to try it out, you will need to call the REST API directly.

Note: This is an experimental implementation, so the behavior may change significantly in the future.

#### Instruction

```
> nslookup -type=CNAME _acme-challenge.example.com

_acme-challenge.example.com     canonical name = _acme-challenge.AliasedDomain.com
```

```javascript
await axios.post("/api/certificate", { dnsNames: ["example.com"], dnsProviderName: "Azure DNS", keyType: "RSA", keySize: 2048, dnsAlias: "AliasedDomain.com" });
```

Close #159 