### PR TITLE
azure private dns txt needs ttl

### DIFF
--- a/KeyVault.Acmebot/Providers/AzurePrivateDnsProvider.cs
+++ b/KeyVault.Acmebot/Providers/AzurePrivateDnsProvider.cs
@@ -45,7 +45,7 @@ internal class AzurePrivateDnsProvider : IDnsProvider
     public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values)
     {
         // TXT レコードに値をセットする
-        var txtRecordData = new PrivateDnsTxtRecordData();
+        var txtRecordData = new PrivateDnsTxtRecordData() { TtlInSeconds = 3600 };
 
         foreach (var value in values)
         {


### PR DESCRIPTION
Azure private DNS TXT record creation is returning a 400. After debugging, I've deduced that it is because no TTL is being provided. This commit introduces a default TTL of 3600 seconds.