### PR TITLE
Fixed deserialize error in Exception

### DIFF
--- a/KeyVault.Acmebot/PreconditionException.cs
+++ b/KeyVault.Acmebot/PreconditionException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace KeyVault.Acmebot;
 
@@ -16,6 +17,11 @@ public class PreconditionException : Exception
 
     public PreconditionException(string message, Exception inner)
         : base(message, inner)
+    {
+    }
+
+    protected PreconditionException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
     }
 }

--- a/KeyVault.Acmebot/RetriableActivityException.cs
+++ b/KeyVault.Acmebot/RetriableActivityException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace KeyVault.Acmebot;
 
@@ -16,6 +17,11 @@ public class RetriableActivityException : Exception
 
     public RetriableActivityException(string message, Exception inner)
         : base(message, inner)
+    {
+    }
+
+    protected RetriableActivityException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
     }
 }

--- a/KeyVault.Acmebot/RetriableOrchestratorException.cs
+++ b/KeyVault.Acmebot/RetriableOrchestratorException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace KeyVault.Acmebot;
 
@@ -16,6 +17,11 @@ public class RetriableOrchestratorException : Exception
 
     public RetriableOrchestratorException(string message, Exception inner)
         : base(message, inner)
+    {
+    }
+
+    protected RetriableOrchestratorException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
     }
 }


### PR DESCRIPTION
The necessary constructor definition for deserializing C# exceptions was removed in the .NET 8 update, causing it to cease functioning correctly.

Fixes #880 