### PR TITLE
Remove `MitigateChainOrder` property

### DIFF
--- a/KeyVault.Acmebot/Functions/SharedActivity.cs
+++ b/KeyVault.Acmebot/Functions/SharedActivity.cs
@@ -424,11 +424,9 @@ public class SharedActivity(
         // 証明書をダウンロードして Key Vault へ格納
         var x509Certificates = await acmeProtocolClient.GetOrderCertificateAsync(orderDetails, _options.PreferredChain);
 
-        var exportedX509Certificates = x509Certificates.Select(x => x.Export(X509ContentType.Pfx));
-
         var mergeCertificateOptions = new MergeCertificateOptions(
             certificateName,
-            _options.MitigateChainOrder ? exportedX509Certificates.Reverse() : exportedX509Certificates
+            [x509Certificates.Export(X509ContentType.Pfx)]
         );
 
         return (await certificateClient.MergeCertificateAsync(mergeCertificateOptions)).Value.ToCertificateItem();

--- a/KeyVault.Acmebot/Options/AcmebotOptions.cs
+++ b/KeyVault.Acmebot/Options/AcmebotOptions.cs
@@ -21,8 +21,6 @@ public class AcmebotOptions
 
     public string PreferredChain { get; set; }
 
-    public bool MitigateChainOrder { get; set; } = false;
-
     [Range(0, 365)]
     public int RenewBeforeExpiry { get; set; } = 30;
 


### PR DESCRIPTION
The latest verification confirmed that the Chain Order issue could no longer be reproduced in Application Gateway, so we are removing the option.