### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       languages: ${{ steps.set-matrix.outputs.languages }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/shibayan/keyvault-acmebot/security/code-scanning/5](https://github.com/shibayan/keyvault-acmebot/security/code-scanning/5)

To fix this problem, you should add a `permissions` block to the `detect-changes` job in `.github/workflows/codeql.yml`. This block should restrict the GITHUB_TOKEN to only the necessary privileges. The `detect-changes` job checks file paths and sets workflow outputs in the context of a pull request or push; it does not appear to require any write access, nor does it push changes or interact with issues, packages, or security features. Therefore, the minimal required permission is likely `contents: read`. The permissions block should be inserted on line 13, immediately after `runs-on: ubuntu-latest`, following the established indentation style.

No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
