### PR TITLE
Fix Bicep publish file path in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,5 +79,5 @@ jobs:
 
     - name: Publish to Private Registry
       run: |
-        az bicep publish --file ./deploy/azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.major_version }} --force
-        az bicep publish --file ./deploy/azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.version }} --force
+        az bicep publish --file azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.major_version }} --force
+        az bicep publish --file azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.version }} --force


### PR DESCRIPTION
This pull request makes a minor update to the publish workflow by changing the path to the `azuredeploy.bicep` file. The file is now referenced from the root directory instead of the `deploy` folder during the publish step. 

- Updated the `Publish to Private Registry` job in `.github/workflows/publish.yml` to use `azuredeploy.bicep` from the root directory instead of `./deploy/azuredeploy.bicep`.