### PR TITLE
Implement nullable handling for certificate names and enhance DNS options with required properties

### DIFF
--- a/src/Acmebot/Functions/RenewCertificate.cs
+++ b/src/Acmebot/Functions/RenewCertificate.cs
@@ -18,6 +18,11 @@ public class RenewCertificate(IHttpContextAccessor httpContextAccessor, ILogger<
     {
         var certificateName = context.GetInput<string>();
 
+        if (string.IsNullOrEmpty(certificateName))
+        {
+            return;
+        }
+
         // 証明書の更新処理を開始
         var certificatePolicyItem = await context.CallGetCertificatePolicyAsync(certificateName);
 

--- a/src/Acmebot/Functions/RevokeCertificate.cs
+++ b/src/Acmebot/Functions/RevokeCertificate.cs
@@ -18,6 +18,11 @@ public class RevokeCertificate(IHttpContextAccessor httpContextAccessor, ILogger
     {
         var certificateName = context.GetInput<string>();
 
+        if (string.IsNullOrEmpty(certificateName))
+        {
+            return;
+        }
+
         await context.CallRevokeCertificateAsync(certificateName);
     }
 

--- a/src/Acmebot/Functions/SharedActivity.cs
+++ b/src/Acmebot/Functions/SharedActivity.cs
@@ -225,7 +225,7 @@ public class SharedActivity(
     }
 
     [Function(nameof(Dns01Authorization))]
-    public async Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization([ActivityTrigger] (string, string, IReadOnlyList<string>) input)
+    public async Task<(IReadOnlyList<AcmeChallengeResult>, int)> Dns01Authorization([ActivityTrigger] (string, string?, IReadOnlyList<string>) input)
     {
         var (dnsProviderName, dnsAlias, authorizationUrls) = input;
 

--- a/src/Acmebot/Options/AzureDnsOptions.cs
+++ b/src/Acmebot/Options/AzureDnsOptions.cs
@@ -2,5 +2,5 @@
 
 public class AzureDnsOptions
 {
-    public string SubscriptionId { get; set; }
+    public required string SubscriptionId { get; set; }
 }

--- a/src/Acmebot/Options/AzurePrivateDnsOptions.cs
+++ b/src/Acmebot/Options/AzurePrivateDnsOptions.cs
@@ -2,5 +2,5 @@
 
 public class AzurePrivateDnsOptions
 {
-    public string SubscriptionId { get; set; }
+    public required string SubscriptionId { get; set; }
 }

--- a/src/Acmebot/Options/CustomDnsOptions.cs
+++ b/src/Acmebot/Options/CustomDnsOptions.cs
@@ -4,9 +4,9 @@ public class CustomDnsOptions
 {
     public int PropagationSeconds { get; set; } = 180;
 
-    public string Endpoint { get; set; }
+    public required string Endpoint { get; set; }
 
-    public string ApiKey { get; set; }
+    public required string ApiKey { get; set; }
 
     public string ApiKeyHeaderName { get; set; } = "X-Api-Key";
 }

--- a/src/Acmebot/Providers/AzureDnsProvider.cs
+++ b/src/Acmebot/Providers/AzureDnsProvider.cs
@@ -29,7 +29,7 @@ public class AzureDnsProvider(AzureDnsOptions options, AzureEnvironment environm
 
         await foreach (var zone in result)
         {
-            zones.Add(new DnsZone(this) { Id = zone.Id, Name = zone.Data.Name, NameServers = zone.Data.NameServers });
+            zones.Add(new DnsZone(this) { Id = zone.Id.ToString(), Name = zone.Data.Name, NameServers = zone.Data.NameServers });
         }
 
         return zones;

--- a/src/Acmebot/Providers/AzurePrivateDnsProvider.cs
+++ b/src/Acmebot/Providers/AzurePrivateDnsProvider.cs
@@ -29,7 +29,7 @@ internal class AzurePrivateDnsProvider(AzurePrivateDnsOptions options, AzureEnvi
 
         await foreach (var zone in result)
         {
-            zones.Add(new DnsZone(this) { Id = zone.Id, Name = zone.Data.Name });
+            zones.Add(new DnsZone(this) { Id = zone.Id.ToString(), Name = zone.Data.Name });
         }
 
         return zones;

--- a/src/Acmebot/Providers/CloudflareProvider.cs
+++ b/src/Acmebot/Providers/CloudflareProvider.cs
@@ -167,7 +167,7 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
         [JsonPropertyName("vanity_name_servers")]
         public string[] VanityNameServers { get; set; }
 
-        [Newtonsoft.Json.JsonIgnore]
+        [JsonIgnore]
         public string[] ActualNameServers => VanityNameServers is { Length: > 0 } ? VanityNameServers : NameServers;
     }
 

--- a/src/Acmebot/Providers/CustomDnsProvider.cs
+++ b/src/Acmebot/Providers/CustomDnsProvider.cs
@@ -35,7 +35,7 @@ public class CustomDnsProvider : IDnsProvider
 
         var zones = await response.Content.ReadAsAsync<Zone[]>();
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name, NameServers = x.NameServers }).ToArray();
+        return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name, NameServers = x.NameServers ?? [] }).ToArray();
     }
 
     public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values)
@@ -59,12 +59,12 @@ public class CustomDnsProvider : IDnsProvider
     private class Zone
     {
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public required string Id { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         [JsonPropertyName("nameServers")]
-        public string[] NameServers { get; set; }
+        public IReadOnlyList<string>? NameServers { get; set; }
     }
 }

--- a/src/Acmebot/Providers/DnsZone.cs
+++ b/src/Acmebot/Providers/DnsZone.cs
@@ -6,15 +6,15 @@ public class DnsZone(IDnsProvider dnsProvider) : IEquatable<DnsZone>
 {
     private static readonly IdnMapping s_idnMapping = new();
 
-    public string Id { get; init; }
+    public required string Id { get; init; }
 
-    public string Name
+    public required string Name
     {
         get;
         init => field = s_idnMapping.GetAscii(value);
     }
 
-    public IReadOnlyList<string> NameServers { get; init; }
+    public IReadOnlyList<string> NameServers { get; init; } = [];
 
     public IDnsProvider DnsProvider { get; } = dnsProvider;
 

--- a/src/Acmebot/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot/Providers/GoogleDnsProvider.cs
@@ -33,7 +33,7 @@ public class GoogleDnsProvider : IDnsProvider
     {
         var zones = new List<ManagedZone>();
 
-        ManagedZonesListResponse response = null;
+        ManagedZonesListResponse? response = null;
 
         do
         {

--- a/src/Acmebot/Providers/Route53Provider.cs
+++ b/src/Acmebot/Providers/Route53Provider.cs
@@ -26,7 +26,7 @@ public class Route53Provider : IDnsProvider
     {
         var zones = new List<HostedZone>();
 
-        ListHostedZonesResponse response = null;
+        ListHostedZonesResponse? response = null;
 
         do
         {

--- a/src/Acmebot/wwwroot/dashboard/index.html
+++ b/src/Acmebot/wwwroot/dashboard/index.html
@@ -1137,6 +1137,18 @@
                   </div>
                 </div>
               </div>
+              <div class="field is-horizontal" v-if="add.useAdvancedOptions">
+                <div class="field-label is-normal">
+                  <label class="label">DNS Alias</label>
+                </div>
+                <div class="field-body">
+                  <div class="field">
+                    <p class="control">
+                      <input v-model="add.dnsAlias" class="input" type="text" placeholder="e.g. alias.example.com">
+                    </p>
+                  </div>
+                </div>
+              </div>
             </section>
             <footer class="modal-card-foot is-justify-content-flex-end">
               <button class="button is-primary" @click="addCertificate" :class="{ 'is-loading': add.sending }">Add</button>
@@ -1389,6 +1401,7 @@
             keySize: "2048",
             keyCurveName: "P-256",
             reuseKey: false,
+            dnsAlias: "",
             loading: false,
             sending: false,
             modalActive: false
@@ -1579,7 +1592,8 @@
             dnsProviderName: this.add.dnsProviderName,
             certificateName: this.add.certificateName,
             keyType: this.add.keyType,
-            reuseKey: this.add.reuseKey
+            reuseKey: this.add.reuseKey,
+            dnsAlias: this.add.dnsAlias
           };
 
           if (this.add.keyType === "RSA") {


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the DNS provider and certificate orchestration components, focusing on stricter type safety, improved input validation, and enhanced user interface options for certificate management. The changes help ensure required fields are properly enforced, input values are validated before processing, and advanced DNS alias options are available in the dashboard.

**Input validation and UI enhancements:**

* Added input validation for `certificateName` in both `RenewCertificate` and `RevokeCertificate` orchestrator methods to prevent processing when the input is missing or empty. [[1]](diffhunk://#diff-e1c251814f9d599f97311f1edacb80e4e54fad2cc38c654911f592f526409589R21-R25) [[2]](diffhunk://#diff-897e6edb75faf5d4e9986c4022146950431888b91415938d2a26d1a59ff75671R21-R25)
* Enhanced the dashboard UI to support DNS alias input when advanced options are enabled, including updating the modal form and passing the `dnsAlias` value through certificate creation. [[1]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1140-R1151) [[2]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1404) [[3]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4L1582-R1596)

**Type safety and required properties:**

* Updated DNS provider options classes (`AzureDnsOptions`, `AzurePrivateDnsOptions`, `CustomDnsOptions`) to use the `required` keyword for essential properties, ensuring these values must be set. [[1]](diffhunk://#diff-f3577595a40c308567013c231babb318ff2e9641e426c1dee26ecbe180d17d75L5-R5) [[2]](diffhunk://#diff-48dbc14f518c837ae6cfd0ea4feabd18b94469a61ac45f1967f1724911af7798L5-R5) [[3]](diffhunk://#diff-0959c36d3bd06c3680f043c50e7046dfb3ce528d4ef22c85818d93b8f94ae925L7-R9)
* Refactored the `DnsZone` class and related provider zone models to enforce required properties and default empty arrays for `NameServers`, improving null safety and consistency. [[1]](diffhunk://#diff-0a60835b3eaee2e9380aea66421990aa2f18d764e1bb4892a20d0cfa2d347b80L9-R17) [[2]](diffhunk://#diff-765b346b27faef7a69c94dbd2dee722f6cf7c847bb61fd1169545777d093cf56L62-R68)

**Provider compatibility and code cleanup:**

* Changed zone ID handling in Azure DNS and Azure Private DNS providers to ensure IDs are always strings, improving compatibility. [[1]](diffhunk://#diff-5e3eab008747fb0ee460cf0859ba1f51c54f08f0c35f40d8f4c103d74834bb37L32-R32) [[2]](diffhunk://#diff-476d5403716174b25c50b707d99653cdfa6090ce09cc79d375df8eb81832b7f1L32-R32)
* Updated nullability and serialization attributes in provider classes for consistency and to prevent potential runtime errors. [[1]](diffhunk://#diff-e08333c6d29d3844e7ab26dab891eb16b471a48c8c83d66c8a235e31129fb05dL228-R228) [[2]](diffhunk://#diff-6b305656df9c717713b117829be96c1073b088bd2875418cd46d898a719ecf65L170-R170) [[3]](diffhunk://#diff-50995960fc90275527564ef40e4305968c84f41a55c91b03d7e6eca27434f0bcL36-R36) [[4]](diffhunk://#diff-af2d5b7e7b459fd5c3e368fd1aa2de631e67789132766a0f70fd21387f65a1b0L29-R29) [[5]](diffhunk://#diff-765b346b27faef7a69c94dbd2dee722f6cf7c847bb61fd1169545777d093cf56L38-R38)