### PR TITLE
Add GitHub Actions workflow for deploying docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d24958b8c9a5c7c3c0f8b7f8c6cd6aa4b8b84 # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@b30ddef9e0ab52c1868e8e475bb665f861b8c125 # v3.0.0
         with:
           path: docs
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@de5298e2de463c1915a29d8044f0c3c3b2c0a5c5 # v4.0.0


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying documentation to GitHub Pages. The workflow is triggered on pushes to the `master` branch and can also be manually triggered. It sets up permissions, concurrency controls, and defines a deployment job that checks out the repository, configures GitHub Pages, uploads the documentation artifact, and deploys it.

Documentation deployment workflow:

* Added `.github/workflows/docs.yml` to automate documentation deployment to GitHub Pages, triggered by pushes to `master` and manual workflow dispatch.
* Configured permissions for repository contents, pages, and ID token, and set up concurrency to prevent overlapping deployments.
* Defined a deployment job that checks out code, configures pages, uploads the `docs` directory as an artifact, and deploys to GitHub Pages.