### PR TITLE
Update documentation links to reflect new repository location

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,8 +33,8 @@
         <a href="#services">Services</a>
         <a href="#providers">DNS Providers</a>
         <a href="#deploy">Deploy</a>
-        <a href="https://github.com/shibayan/keyvault-acmebot/wiki" class="nav-link-docs">Docs</a>
-        <a href="https://github.com/shibayan/keyvault-acmebot" class="nav-link-github" aria-label="GitHub">
+        <a href="https://github.com/polymind-inc/acmebot/wiki" class="nav-link-docs">Docs</a>
+        <a href="https://github.com/polymind-inc/acmebot" class="nav-link-github" aria-label="GitHub">
           <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
           </svg>
@@ -54,7 +54,7 @@
       <p class="hero-description">Securely manage ACME certificates with Azure Key Vault.<br class="hide-mobile"> Issue, renew, and deploy certificates across your Azure services with production-ready automation.</p>
       <div class="hero-actions">
         <a href="#deploy" class="btn btn-primary">Deploy to Azure</a>
-        <a href="https://github.com/shibayan/keyvault-acmebot/wiki/Getting-Started" class="btn btn-outline">Get Started</a>
+        <a href="https://github.com/polymind-inc/acmebot/wiki/Getting-Started" class="btn btn-outline">Get Started</a>
       </div>
       <div class="hero-stats">
         <div class="hero-stat">
@@ -287,9 +287,9 @@
             <li>.NET 10 runtime</li>
           </ul>
           <div class="deploy-buttons">
-            <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-primary btn-deploy">Azure Public</a>
-            <a href="https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-outline btn-deploy">Azure China</a>
-            <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-outline btn-deploy">Azure Government</a>
+            <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-primary btn-deploy">Azure Public</a>
+            <a href="https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-outline btn-deploy">Azure China</a>
+            <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy.json" class="btn btn-outline btn-deploy">Azure Government</a>
           </div>
         </div>
         <div class="deploy-card">
@@ -300,9 +300,9 @@
             <li>.NET 8 runtime</li>
           </ul>
           <div class="deploy-buttons">
-            <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-secondary btn-deploy">Azure Public</a>
-            <a href="https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-outline btn-deploy">Azure China</a>
-            <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshibayan%2Fkeyvault-acmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-outline btn-deploy">Azure Government</a>
+            <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-secondary btn-deploy">Azure Public</a>
+            <a href="https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-outline btn-deploy">Azure China</a>
+            <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fazuredeploy_v4.json" class="btn btn-outline btn-deploy">Azure Government</a>
           </div>
         </div>
       </div>
@@ -335,7 +335,7 @@
         </div>
       </div>
       <div class="steps-cta">
-        <a href="https://github.com/shibayan/keyvault-acmebot/wiki/Getting-Started" class="btn btn-primary">Read the Documentation</a>
+        <a href="https://github.com/polymind-inc/acmebot/wiki/Getting-Started" class="btn btn-primary">Read the Documentation</a>
       </div>
     </div>
   </section>
@@ -363,17 +363,17 @@
       <h2 class="section-title">Open Source</h2>
       <p class="section-subtitle">Apache License 2.0 — free to use, forever</p>
       <div class="community-grid">
-        <a href="https://github.com/shibayan/keyvault-acmebot" class="community-card">
+        <a href="https://github.com/polymind-inc/acmebot" class="community-card">
           <svg viewBox="0 0 16 16" width="24" height="24" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           <strong>GitHub</strong>
           <p>Source code, issues, and contributions</p>
         </a>
-        <a href="https://github.com/shibayan/keyvault-acmebot/wiki" class="community-card">
+        <a href="https://github.com/polymind-inc/acmebot/wiki" class="community-card">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>
           <strong>Documentation</strong>
           <p>Setup guides and configuration reference</p>
         </a>
-        <a href="https://github.com/shibayan/keyvault-acmebot/discussions" class="community-card">
+        <a href="https://github.com/polymind-inc/acmebot/discussions" class="community-card">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
           <strong>Discussions</strong>
           <p>Questions, ideas, and community support</p>
@@ -393,15 +393,15 @@
         <div class="footer-links">
           <div class="footer-col">
             <h4>Project</h4>
-            <a href="https://github.com/shibayan/keyvault-acmebot">GitHub</a>
-            <a href="https://github.com/shibayan/keyvault-acmebot/releases">Releases</a>
-            <a href="https://github.com/shibayan/keyvault-acmebot/blob/master/LICENSE">License</a>
+            <a href="https://github.com/polymind-inc/acmebot">GitHub</a>
+            <a href="https://github.com/polymind-inc/acmebot/releases">Releases</a>
+            <a href="https://github.com/polymind-inc/acmebot/blob/master/LICENSE">License</a>
           </div>
           <div class="footer-col">
             <h4>Resources</h4>
-            <a href="https://github.com/shibayan/keyvault-acmebot/wiki">Documentation</a>
-            <a href="https://github.com/shibayan/keyvault-acmebot/wiki/Getting-Started">Getting Started</a>
-            <a href="https://github.com/shibayan/keyvault-acmebot/discussions">Discussions</a>
+            <a href="https://github.com/polymind-inc/acmebot/wiki">Documentation</a>
+            <a href="https://github.com/polymind-inc/acmebot/wiki/Getting-Started">Getting Started</a>
+            <a href="https://github.com/polymind-inc/acmebot/discussions">Discussions</a>
           </div>
           <div class="footer-col">
             <h4>Support</h4>


### PR DESCRIPTION
This pull request updates all links in the `docs/index.html` file to point from the old `shibayan/keyvault-acmebot` GitHub repository to the new `polymind-inc/acmebot` repository. This ensures users are directed to the correct project location for documentation, source code, discussions, and deployment templates.

Repository migration updates:

* Changed all GitHub links throughout `docs/index.html` (including navigation, hero actions, community cards, and footer) to reference `polymind-inc/acmebot` instead of `shibayan/keyvault-acmebot`, ensuring users are directed to the new repository for source code, documentation, discussions, and releases. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL36-R37) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL57-R57) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL338-R338) [[4]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL366-R376) [[5]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL396-R404)

Deployment template links:

* Updated Azure deployment template links for .NET 10 and .NET 8 runtimes to use templates from the `polymind-inc/acmebot` repository, so new deployments reference the correct source. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL290-R292) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL303-R305)