### PR TITLE
Disable Add Certificate button when no DNS Names selected

### DIFF
--- a/src/Acmebot/wwwroot/dashboard/index.html
+++ b/src/Acmebot/wwwroot/dashboard/index.html
@@ -1151,7 +1151,7 @@
               </div>
             </section>
             <footer class="modal-card-foot is-justify-content-flex-end">
-              <button class="button is-primary" @click="addCertificate" :class="{ 'is-loading': add.sending }">Add</button>
+              <button class="button is-primary" @click="addCertificate" :class="{ 'is-loading': add.sending }" :disabled="add.dnsNames.length === 0">Add</button>
               <button class="button" @click="add.modalActive = false" :disabled="add.sending">Cancel</button>
             </footer>
           </div>


### PR DESCRIPTION
## Summary

In the Add Certificates modal, it is easy to accidentally submit a request without any DNS names. This can happen if the user enters a DNS name but forgets to click the “Add” button next to the DNS Names field before submitting the form. Because the request succeeds without an error, this behavior can be confusing, especially for first-time users.

## Related Issue

None found

## What Changed

Disable the "Add" button on the Add Certificates modal until a DNS Name has been added.


## Validation

- [x] `dotnet build -c Release ./src`
- [x] `dotnet format --verify-no-changes --exclude ./src/ACMESharpCore --verbosity detailed --no-restore ./src`
- [x] `az bicep build -f ./deploy/azuredeploy.bicep`
- [x] Documentation updated if needed