### PR TITLE
Fix error handling in certificate operations to ensure proper state management

### DIFF
--- a/src/Acmebot/wwwroot/dashboard/index.html
+++ b/src/Acmebot/wwwroot/dashboard/index.html
@@ -1616,9 +1616,11 @@
             }
           } catch (error) {
             this.handleHttpError(error);
+            return;
+          } finally {
+            this.add.sending = false;
           }
 
-          this.add.sending = false;
           this.add.modalActive = false;
 
           await this.showNotify("The certificate was successfully issued.");
@@ -1655,9 +1657,11 @@
             }
           } catch (error) {
             this.handleHttpError(error);
+            return;
+          } finally {
+            this.details.sending = false;
           }
 
-          this.details.sending = false;
           this.details.modalActive = false;
 
           await this.showNotify("The certificate was successfully renewed.");
@@ -1673,9 +1677,11 @@
             await axios.post(`/api/certificate/${this.details.certificate.name}/revoke`);
           } catch (error) {
             this.handleHttpError(error);
+            return;
+          } finally {
+            this.details.sending = false;
           }
 
-          this.details.sending = false;
           this.details.modalActive = false;
 
           await this.showNotify("The certificate was successfully revoked.");


### PR DESCRIPTION
This pull request improves error handling and UI responsiveness in the certificate management workflows on the dashboard. The main changes ensure that UI state is properly updated after API actions, even when errors occur, by using `finally` blocks and early returns.

Enhancements to error handling and UI state management:

* Added `finally` blocks to set `sending` flags (`this.add.sending`, `this.details.sending`) to `false` after issuing, renewing, or revoking certificates, ensuring UI loading indicators are cleared regardless of success or failure. [[1]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1619-L1621) [[2]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1660-L1660) [[3]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1680-L1678)
* Inserted early `return` statements after error handling to prevent further UI updates and notifications when an error occurs during certificate actions. [[1]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1619-L1621) [[2]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1660-L1660) [[3]](diffhunk://#diff-cbd44e6943b016fa3d4d68fd05e5f684c5ef951eb6a2829c4f2be7a2e096f4f4R1680-L1678)

Close #982 #983 