### PR TITLE
Remove security vulnerability reporting link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Ask a question
     url: https://github.com/polymind-inc/acmebot/discussions/new
     about: Ask a question about this project
-  - name: Report a security vulnerability
-    url: https://github.com/polymind-inc/acmebot/security/policy
-    about: Review the security policy before reporting a vulnerability


### PR DESCRIPTION
Removed the link for reporting security vulnerabilities from the issue template.