### PR TITLE
Add OpenTelemetry support and remove Application Insights initializer

### DIFF
--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Akamai.EdgeGrid.Auth" Version="1.0.0-preview" />
     <PackageReference Include="AWSSDK.Route53" Version="4.0.8.12" />
     <PackageReference Include="Azure.Identity" Version="1.19.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
     <PackageReference Include="Azure.ResourceManager.Dns" Version="1.1.1" />
     <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
@@ -21,14 +22,14 @@
     <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="Functions.Worker.Extensions.HttpApi" Version="3.0.5" />
     <PackageReference Include="Google.Apis.Dns.v1" Version="1.73.0.4067" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="2.1.0-preview.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Acmebot.App/Infrastructure/ApplicationVersionInitializer.cs
+++ b/src/Acmebot.App/Infrastructure/ApplicationVersionInitializer.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
-
-namespace Acmebot.App.Infrastructure;
-
-internal class ApplicationVersionInitializer : ITelemetryInitializer
-{
-    public void Initialize(ITelemetry telemetry) => telemetry.Context.Component.Version = Constants.ApplicationVersion;
-}

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -10,13 +10,13 @@ using Acmebot.App.Providers;
 using Azure.Core;
 using Azure.Functions.Worker.Extensions.HttpApi.Config;
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Certificates;
 
 using DnsClient;
 
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -24,11 +24,11 @@ using Microsoft.Extensions.Options;
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication()
-    .AddHttpApi();
+       .AddHttpApi();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+builder.Services.AddOpenTelemetry()
+       .UseFunctionsWorkerDefaults()
+       .UseAzureMonitorExporter();
 
 builder.Services.Configure<JsonSerializerOptions>(options =>
 {
@@ -43,8 +43,6 @@ builder.Services.AddOptions<AcmebotOptions>()
 
 // Add Services
 builder.Services.AddHttpClient();
-
-builder.Services.AddSingleton<ITelemetryInitializer, ApplicationVersionInitializer>();
 
 builder.Services.AddSingleton(provider =>
 {

--- a/src/Acmebot.App/host.json
+++ b/src/Acmebot.App/host.json
@@ -1,14 +1,9 @@
 {
   "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
   "logging": {
-    "applicationInsights": {
-      "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request;Exception"
-      }
-    },
     "logLevel": {
-      "Acmebot.App": "Warning"
+      "default": "Warning"
     }
   },
   "extensions": {


### PR DESCRIPTION
This pull request updates the application's telemetry and monitoring stack by migrating from Application Insights to OpenTelemetry with Azure Monitor Exporter. This modernizes observability, aligns with current best practices, and simplifies related configuration and code. The most important changes are grouped below.

**Migration to OpenTelemetry and Azure Monitor Exporter:**

* Removed dependencies on `Microsoft.ApplicationInsights.WorkerService` and `Microsoft.Azure.Functions.Worker.ApplicationInsights`, and added new dependencies for `Azure.Monitor.OpenTelemetry.Exporter`, `Microsoft.Azure.Functions.Worker.OpenTelemetry`, and `OpenTelemetry.Extensions.Hosting` in `Acmebot.App.csproj`.
* Replaced Application Insights telemetry setup in `Program.cs` with OpenTelemetry initialization using `AddOpenTelemetry()`, `UseFunctionsWorkerDefaults()`, and `UseAzureMonitorExporter()`.
* Updated `host.json` to set `"telemetryMode": "OpenTelemetry"` and removed Application Insights-specific logging configuration.

**Codebase cleanup:**

* Removed the custom `ApplicationVersionInitializer` class and its registration, as it was specific to Application Insights. [[1]](diffhunk://#diff-d4d303c450908be08526ed2b19d4b77c91535846c4cecf6658877514d0733892L1-L9) [[2]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557L47-L48)

**General code and dependency updates:**

* Updated `using` statements in `Program.cs` to remove Application Insights references and add OpenTelemetry/Azure Monitor references as needed.