### PR TITLE
Refactor unify DNS provider TXT record creation APIs

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
@@ -152,7 +152,7 @@ public class DnsChallengeActivities(
             var acmeDnsRecordName = dnsRecordName.Replace($".{zone.Name}", "", StringComparison.OrdinalIgnoreCase);
 
             await zone.DnsProvider.DeleteTxtRecordAsync(zone, acmeDnsRecordName, cancellationToken);
-            await zone.DnsProvider.CreateTxtRecordAsync(zone, acmeDnsRecordName, lookup.Select(x => x.DnsRecordValue), cancellationToken);
+            await zone.DnsProvider.CreateTxtRecordAsync(zone, acmeDnsRecordName, lookup.Select(x => x.DnsRecordValue).ToArray(), cancellationToken);
 
             propagationSeconds = Math.Max(propagationSeconds, (int)zone.DnsProvider.PropagationDelay.TotalSeconds);
         }

--- a/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
@@ -29,7 +29,7 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
         return zones;
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}";
 
@@ -38,10 +38,10 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
             Name = recordName,
             Type = "TXT",
             Ttl = 60,
-            Rdata = values.ToArray()
+            Rdata = values
         };
 
-        await _akamaiEdgeDnsClient.CreateOrUpdateRecordAsync(zone.Name, recordName, "TXT", recordSet, cancellationToken);
+        await _akamaiEdgeDnsClient.CreateRecordAsync(zone.Name, recordSet, cancellationToken);
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
@@ -72,18 +72,17 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
         public async IAsyncEnumerable<ZoneResult> ListZonesInternalAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var page = 1;
-            const int pageSize = 100;
 
             while (true)
             {
-                var result = await _httpClient.GetFromJsonAsync<ZonesResponse>($"zones?page={page}&pageSize={pageSize}", cancellationToken);
+                var result = await _httpClient.GetFromJsonAsync<ZonesResponse>($"zones?page={page}&pageSize=100&types=PRIMARY", cancellationToken);
 
                 if (result?.Zones is null or { Length: 0 })
                 {
                     break;
                 }
 
-                foreach (var zone in result.Zones)
+                foreach (var zone in result.Zones.Where(x => x.ActivationState == "ACTIVE"))
                 {
                     yield return zone;
                 }
@@ -92,9 +91,9 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
             }
         }
 
-        public async Task CreateOrUpdateRecordAsync(string zone, string name, string type, RecordSet recordSet, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string zone, RecordSet recordSet, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.PostAsJsonAsync($"zones/{zone}/names/{name}/types/{type}", recordSet, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync($"zones/{zone}/names/{recordSet.Name}/types/{recordSet.Type}", recordSet, cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
@@ -109,23 +108,8 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
 
     internal class ZonesResponse
     {
-        [JsonPropertyName("metadata")]
-        public Metadata? Metadata { get; set; }
-
         [JsonPropertyName("zones")]
         public ZoneResult[]? Zones { get; set; }
-    }
-
-    internal class Metadata
-    {
-        [JsonPropertyName("page")]
-        public int Page { get; set; }
-
-        [JsonPropertyName("pageSize")]
-        public int PageSize { get; set; }
-
-        [JsonPropertyName("totalElements")]
-        public int TotalElements { get; set; }
     }
 
     internal class ZoneResult
@@ -136,9 +120,6 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
         [JsonPropertyName("type")]
         public string? Type { get; set; }
 
-        [JsonPropertyName("contractId")]
-        public string? ContractId { get; set; }
-
         [JsonPropertyName("activationState")]
         public string? ActivationState { get; set; }
     }
@@ -146,10 +127,10 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
     internal class RecordSet
     {
         [JsonPropertyName("name")]
-        public string? Name { get; set; }
+        public required string Name { get; set; }
 
         [JsonPropertyName("type")]
-        public string? Type { get; set; }
+        public required string Type { get; set; }
 
         [JsonPropertyName("ttl")]
         public int Ttl { get; set; }

--- a/src/Acmebot.App/Providers/AzureDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AzureDnsProvider.cs
@@ -33,7 +33,7 @@ public class AzureDnsProvider(AzureDnsOptions options, AzureEnvironment environm
         return zones;
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         // TXT レコードに値をセットする
         var txtRecordData = new DnsTxtRecordData

--- a/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
@@ -33,7 +33,7 @@ public class AzurePrivateDnsProvider(AzurePrivateDnsOptions options, AzureEnviro
         return zones;
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         // TXT レコードに値をセットする
         var txtRecordData = new PrivateDnsTxtRecordData

--- a/src/Acmebot.App/Providers/CloudflareProvider.cs
+++ b/src/Acmebot.App/Providers/CloudflareProvider.cs
@@ -28,14 +28,21 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
         return zones;
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}";
 
-        // 必要な検証用の値の数だけ新しく追加する
         foreach (var value in values)
         {
-            await _cloudflareClient.CreateDnsRecordAsync(zone.Id, recordName, value, cancellationToken);
+            var record = new RecordParam
+            {
+                Name = recordName,
+                Type = "TXT",
+                Ttl = 60,
+                Content = value
+            };
+
+            await _cloudflareClient.CreateDnsRecordAsync(zone.Id, record, cancellationToken);
         }
     }
 
@@ -45,7 +52,6 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
 
         var records = await _cloudflareClient.ListDnsRecordsAsync(zone.Id, recordName, cancellationToken);
 
-        // 該当する全てのレコードを削除する
         foreach (var record in records)
         {
             try
@@ -97,30 +103,23 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
             } while (page++ < (result.ResultInfo?.TotalPages ?? 1));
         }
 
-        public async Task<IReadOnlyList<TxtRecord>> ListDnsRecordsAsync(string zone, string name, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<Record>> ListDnsRecordsAsync(string zoneId, string recordName, CancellationToken cancellationToken = default)
         {
-            var result = await _httpClient.GetFromJsonAsync<PagePaginationArray<TxtRecord>>($"zones/{zone}/dns_records?type=TXT&name={name}&per_page=100", cancellationToken);
+            var result = await _httpClient.GetFromJsonAsync<PagePaginationArray<Record>>($"zones/{zoneId}/dns_records?type=TXT&name={recordName}&per_page=100", cancellationToken);
 
             return result?.Result ?? [];
         }
 
-        public async Task CreateDnsRecordAsync(string zone, string name, string content, CancellationToken cancellationToken = default)
+        public async Task CreateDnsRecordAsync(string zoneId, RecordParam record, CancellationToken cancellationToken = default)
         {
-            var recordParam = new TxtRecordParam
-            {
-                Name = name,
-                Content = content,
-                Ttl = 60
-            };
-
-            var response = await _httpClient.PostAsJsonAsync($"zones/{zone}/dns_records", recordParam, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync($"zones/{zoneId}/dns_records", record, cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task DeleteDnsRecordAsync(string zone, string id, CancellationToken cancellationToken = default)
+        public async Task DeleteDnsRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.DeleteAsync($"zones/{zone}/dns_records/{id}", cancellationToken);
+            var response = await _httpClient.DeleteAsync($"zones/{zoneId}/dns_records/{recordId}", cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
@@ -162,22 +161,22 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
         public string[] ActualNameServers => VanityNameServers is { Length: > 0 } ? VanityNameServers : NameServers;
     }
 
-    internal class TxtRecordParam
+    internal class RecordParam
     {
         [JsonPropertyName("name")]
         public required string Name { get; set; }
 
         [JsonPropertyName("ttl")]
-        public int Ttl { get; set; } = 1;
+        public int Ttl { get; set; }
 
         [JsonPropertyName("type")]
-        public string Type => "TXT";
+        public required string Type { get; set; }
 
         [JsonPropertyName("content")]
         public string? Content { get; set; }
     }
 
-    internal class TxtRecord : TxtRecordParam
+    internal class Record : RecordParam
     {
         [JsonPropertyName("id")]
         public required string Id { get; set; }

--- a/src/Acmebot.App/Providers/CustomDnsProvider.cs
+++ b/src/Acmebot.App/Providers/CustomDnsProvider.cs
@@ -1,63 +1,102 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 using Acmebot.App.Options;
 
 namespace Acmebot.App.Providers;
 
-public class CustomDnsProvider : IDnsProvider
+public class CustomDnsProvider(CustomDnsOptions options) : IDnsProvider
 {
-    public CustomDnsProvider(CustomDnsOptions options)
-    {
-        _httpClient = new HttpClient
-        {
-            BaseAddress = new Uri(options.Endpoint)
-        };
-
-        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation(options.ApiKeyHeaderName, options.ApiKey);
-
-        PropagationDelay = TimeSpan.FromSeconds(options.PropagationSeconds);
-    }
-
-    private readonly HttpClient _httpClient;
+    private readonly CustomDnsClient _customDnsClient = new(options.Endpoint, options.ApiKey, options.ApiKeyHeaderName);
 
     public string Name => "Custom DNS";
 
-    public TimeSpan PropagationDelay { get; }
+    public TimeSpan PropagationDelay { get; } = TimeSpan.FromSeconds(options.PropagationSeconds);
 
     public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
     {
-        var zones = await _httpClient.GetFromJsonAsync<Zone[]>("zones", cancellationToken) ?? [];
+        var zones = new List<DnsZone>();
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name, NameServers = x.NameServers ?? [] }).ToArray();
+        await foreach (var zone in _customDnsClient.ListZonesAsync(cancellationToken))
+        {
+            zones.Add(new DnsZone(this) { Id = zone.Id, Name = zone.Name, NameServers = zone.NameServers ?? [] });
+        }
+
+        return zones;
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}";
 
-        var txtRecordParam = new TxtRecordParam
+        var record = new RecordParam
         {
+            Type = "TXT",
             Ttl = 60,
-            Values = values.ToArray()
+            Values = values
         };
 
-        var response = await _httpClient.PutAsJsonAsync($"zones/{zone.Id}/records/{recordName}", txtRecordParam, cancellationToken);
-
-        response.EnsureSuccessStatusCode();
+        await _customDnsClient.CreateRecordAsync(zone.Id, recordName, record, cancellationToken);
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}";
 
-        var response = await _httpClient.DeleteAsync($"zones/{zone.Id}/records/{recordName}", cancellationToken);
-
-        if (response.StatusCode != HttpStatusCode.NotFound)
+        try
         {
+            await _customDnsClient.DeleteRecordAsync(zone.Id, recordName, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // ignored
+        }
+    }
+
+    private class CustomDnsClient
+    {
+        public CustomDnsClient(string endpoint, string apiKey, string apiKeyHeaderName)
+        {
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(endpoint)
+            };
+
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation(apiKeyHeaderName, apiKey);
+        }
+
+        private readonly HttpClient _httpClient;
+
+        public async IAsyncEnumerable<Zone> ListZonesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var zones = await _httpClient.GetFromJsonAsync<Zone[]>("zones", cancellationToken);
+
+            if (zones is null or { Length: 0 })
+            {
+                yield break;
+            }
+
+            foreach (var zone in zones)
+            {
+                yield return zone;
+            }
+        }
+
+        public async Task CreateRecordAsync(string zoneId, string recordName, RecordParam record, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.PutAsJsonAsync($"zones/{zoneId}/records/{recordName}", record, cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRecordAsync(string zoneId, string recordName, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.DeleteAsync($"zones/{zoneId}/records/{recordName}", cancellationToken);
+
             response.EnsureSuccessStatusCode();
         }
     }
@@ -71,18 +110,18 @@ public class CustomDnsProvider : IDnsProvider
         public required string Name { get; set; }
 
         [JsonPropertyName("nameServers")]
-        public IReadOnlyList<string>? NameServers { get; set; }
+        public string[]? NameServers { get; set; }
     }
 
-    internal class TxtRecordParam
+    internal class RecordParam
     {
         [JsonPropertyName("type")]
-        public string Type => "TXT";
+        public required string Type { get; set; }
 
         [JsonPropertyName("ttl")]
         public int Ttl { get; set; }
 
         [JsonPropertyName("values")]
-        public IReadOnlyList<string>? Values { get; set; }
+        public string[]? Values { get; set; }
     }
 }

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -11,7 +11,7 @@ namespace Acmebot.App.Providers;
 
 public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
 {
-    private readonly DnsMadeEasyClient _client = new(options.ApiKey, options.SecretKey);
+    private readonly DnsMadeEasyClient _dnsMadeEasyClient = new(options.ApiKey, options.SecretKey);
 
     public string Name => "DNS Made Easy";
 
@@ -19,29 +19,30 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
 
     public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
     {
-        var zones = await _client.ListDomainsAsync(cancellationToken);
+        var zones = await _dnsMadeEasyClient.ListDomainsAsync(cancellationToken);
 
         return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name }).ToArray();
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         foreach (var value in values)
         {
-            var record = new TxtRecordParam
+            var record = new RecordParam
             {
                 Name = relativeRecordName,
+                Type = "TXT",
                 Ttl = 60,
                 Value = value
             };
 
-            await _client.AddRecordAsync(zone.Id, record, cancellationToken);
+            await _dnsMadeEasyClient.CreateRecordAsync(zone.Id, record, cancellationToken);
         }
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
-        var records = await _client.ListRecordsAsync(zone.Id, cancellationToken);
+        var records = await _dnsMadeEasyClient.ListRecordsAsync(zone.Id, cancellationToken);
 
         var recordsToDelete = records.Where(x => x.Name == relativeRecordName && x.Type == "TXT");
 
@@ -49,7 +50,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
         {
             try
             {
-                await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+                await _dnsMadeEasyClient.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
@@ -79,9 +80,9 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
             return result?.Data ?? [];
         }
 
-        public async Task<IReadOnlyList<TxtRecord>> ListRecordsAsync(string zoneId, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<Record>> ListRecordsAsync(string zoneId, CancellationToken cancellationToken = default)
         {
-            var entries = await _httpClient.GetFromJsonAsync<PaginationArray<TxtRecord>>($"managed/{zoneId}/records", cancellationToken);
+            var entries = await _httpClient.GetFromJsonAsync<PaginationArray<Record>>($"managed/{zoneId}/records", cancellationToken);
 
             return entries?.Data ?? [];
         }
@@ -93,7 +94,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task AddRecordAsync(string zoneId, TxtRecordParam txtRecord, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string zoneId, RecordParam txtRecord, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync($"managed/{zoneId}/records", txtRecord, cancellationToken);
 
@@ -149,7 +150,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
         public required string Name { get; set; }
     }
 
-    internal class TxtRecordParam
+    internal class RecordParam
     {
         [JsonPropertyName("name")]
         public required string Name { get; set; }
@@ -158,13 +159,13 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
         public int Ttl { get; set; }
 
         [JsonPropertyName("type")]
-        public string Type => "TXT";
+        public required string Type { get; set; }
 
         [JsonPropertyName("value")]
         public string? Value { get; set; }
     }
 
-    internal class TxtRecord : TxtRecordParam
+    internal class Record : RecordParam
     {
         [JsonPropertyName("id")]
         public required string Id { get; set; }

--- a/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
@@ -28,14 +28,23 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
         return zones;
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
-        => _gandiLiveDnsClient.AddRecordAsync(zone.Name, relativeRecordName, values, cancellationToken);
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
+    {
+        var record = new Record
+        {
+            RrsetType = "TXT",
+            RrsetValues = values,
+            RrsetTtl = 300
+        };
+
+        return _gandiLiveDnsClient.CreateRecordAsync(zone.Name, relativeRecordName, record, cancellationToken);
+    }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
         try
         {
-            await _gandiLiveDnsClient.DeleteRecordAsync(zone.Name, relativeRecordName, cancellationToken);
+            await _gandiLiveDnsClient.DeleteRecordAsync(zone.Name, relativeRecordName, "TXT", cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -80,21 +89,16 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
             }
         }
 
-        public async Task DeleteRecordAsync(string zoneName, string relativeRecordName, CancellationToken cancellationToken = default)
+        public async Task DeleteRecordAsync(string zoneName, string relativeRecordName, string rrsetType, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.DeleteAsync($"livedns/domains/{zoneName}/records/{relativeRecordName}/TXT", cancellationToken);
+            var response = await _httpClient.DeleteAsync($"livedns/domains/{zoneName}/records/{relativeRecordName}/{rrsetType}", cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task AddRecordAsync(string zoneName, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string zoneName, string relativeRecordName, Record record, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.PostAsJsonAsync($"livedns/domains/{zoneName}/records/{relativeRecordName}", new Record
-            {
-                RrsetType = "TXT",
-                RrsetValues = values.ToArray(),
-                RrsetTtl = 300
-            }, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync($"livedns/domains/{zoneName}/records/{relativeRecordName}", record, cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }

--- a/src/Acmebot.App/Providers/GoDaddyProvider.cs
+++ b/src/Acmebot.App/Providers/GoDaddyProvider.cs
@@ -28,11 +28,11 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
         return zones;
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var entries = values.Select(x => new DnsEntry { Name = relativeRecordName, Type = "TXT", Ttl = 600, Data = x }).ToArray();
 
-        return _goDaddyClient.AddRecordAsync(zone.Name, entries, cancellationToken);
+        return _goDaddyClient.CreateRecordAsync(zone.Name, entries, cancellationToken);
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
@@ -68,9 +68,9 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
 
             while (true)
             {
-                var domains = await _httpClient.GetFromJsonAsync<ZoneDomain[]>($"domains?statuses=ACTIVE&includes=nameServers&limit=1000&marker={marker}", cancellationToken) ?? [];
+                var domains = await _httpClient.GetFromJsonAsync<ZoneDomain[]>($"domains?statuses=ACTIVE&includes=nameServers&limit=1000&marker={marker}", cancellationToken);
 
-                if (domains.Length == 0)
+                if (domains is null or { Length: 0 })
                 {
                     break;
                 }
@@ -84,14 +84,14 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
             }
         }
 
-        public async Task DeleteRecordAsync(string domain, string type, string name, CancellationToken cancellationToken = default)
+        public async Task DeleteRecordAsync(string domain, string type, string recordName, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.DeleteAsync($"domains/{domain}/records/{type}/{name}", cancellationToken);
+            var response = await _httpClient.DeleteAsync($"domains/{domain}/records/{type}/{recordName}", cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task AddRecordAsync(string domain, IReadOnlyList<DnsEntry> entries, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string domain, IReadOnlyList<DnsEntry> entries, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PatchAsJsonAsync($"domains/{domain}/records", entries, cancellationToken);
 

--- a/src/Acmebot.App/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GoogleDnsProvider.cs
@@ -47,7 +47,7 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
                     .ToArray();
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}.";
 
@@ -60,7 +60,7 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
                     Name = recordName,
                     Type = "TXT",
                     Ttl = 60,
-                    Rrdatas = values.ToArray()
+                    Rrdatas = values
                 }
             ]
         };

--- a/src/Acmebot.App/Providers/IDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IDnsProvider.cs
@@ -5,6 +5,6 @@ public interface IDnsProvider
     string Name { get; }
     TimeSpan PropagationDelay { get; }
     Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default);
-    Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default);
+    Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default);
     Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default);
 }

--- a/src/Acmebot.App/Providers/IonosDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IonosDnsProvider.cs
@@ -28,11 +28,19 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
         return zones;
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         foreach (var value in values)
         {
-            await _ionosDnsClient.CreateRecordAsync(zone.Id, relativeRecordName, value, cancellationToken);
+            var record = new RecordParam
+            {
+                Name = relativeRecordName,
+                Type = "TXT",
+                Content = value,
+                Ttl = 60
+            };
+
+            await _ionosDnsClient.CreateRecordAsync(zone.Id, record, cancellationToken);
         }
     }
 
@@ -90,17 +98,9 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
             return result?.Records ?? [];
         }
 
-        public async Task CreateRecordAsync(string zoneId, string recordName, string content, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string zoneId, RecordParam record, CancellationToken cancellationToken = default)
         {
-            var recordParam = new RecordParam
-            {
-                Name = recordName,
-                Type = "TXT",
-                Content = content,
-                Ttl = 60
-            };
-
-            var response = await _httpClient.PostAsJsonAsync($"zones/{zoneId}/records", recordParam, cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync($"zones/{zoneId}/records", record, cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }

--- a/src/Acmebot.App/Providers/Route53Provider.cs
+++ b/src/Acmebot.App/Providers/Route53Provider.cs
@@ -32,7 +32,7 @@ public class Route53Provider(Route53Options options) : IDnsProvider
         return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name.TrimEnd('.') }).ToArray();
     }
 
-    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}.";
 

--- a/src/Acmebot.App/Providers/TransIpProvider.cs
+++ b/src/Acmebot.App/Providers/TransIpProvider.cs
@@ -37,7 +37,7 @@ public class TransIpProvider : IDnsProvider
         return zones.Select(x => new DnsZone(this) { Id = x.Name, Name = x.Name, NameServers = x.NameServers?.Select(xs => xs.Hostname).ToArray() ?? [] }).ToArray();
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, IEnumerable<string> values, CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
         foreach (var value in values)
         {
@@ -49,7 +49,7 @@ public class TransIpProvider : IDnsProvider
                 Content = value
             };
 
-            await _transIpClient.AddRecordAsync(zone.Name, entry, cancellationToken);
+            await _transIpClient.CreateRecordAsync(zone.Name, entry, cancellationToken);
         }
     }
 
@@ -112,7 +112,7 @@ public class TransIpProvider : IDnsProvider
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task AddRecordAsync(string zoneName, DnsEntry entry, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(string zoneName, DnsEntry entry, CancellationToken cancellationToken = default)
         {
             var request = new DnsEntryRequest
             {


### PR DESCRIPTION
- change IDnsProvider.CreateTxtRecordAsync to accept string[] values
- materialize ACME TXT values before passing them to providers
- align provider client methods around CreateRecord naming and typed record payloads
- simplify provider implementations by removing redundant ToArray calls
- refine provider-specific DNS API handling for Akamai, Cloudflare, Gandi, GoDaddy, IONOS, and Custom DNS