### PR TITLE
Include PENDING_DNS_ACTIVE domains in GoDaddy provider zone listing

### DIFF
--- a/src/Acmebot.App/Providers/GoDaddyProvider.cs
+++ b/src/Acmebot.App/Providers/GoDaddyProvider.cs
@@ -68,7 +68,7 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
 
             while (true)
             {
-                var domains = await _httpClient.GetFromJsonAsync<ZoneDomain[]>($"domains?statuses=ACTIVE&includes=nameServers&limit=1000&marker={marker}", cancellationToken);
+                var domains = await _httpClient.GetFromJsonAsync<ZoneDomain[]>($"domains?statuses=ACTIVE,PENDING_DNS_ACTIVE&includes=nameServers&limit=1000&marker={marker}", cancellationToken);
 
                 if (domains is null or { Length: 0 })
                 {


### PR DESCRIPTION
Domains registered at a different registrar but with DNS hosted at GoDaddy have a status of PENDING_DNS_ACTIVE rather than ACTIVE. These domains have fully functional DNS zones but were excluded from the zone listing, preventing certificate issuance for those domains.

## Summary

- GoDaddy provider excludes domains with PENDING_DNS_ACTIVE status from zone listing, even when DNS is fully functional

## Related Issue

- N/A

## What Changed

- Added PENDING_DNS_ACTIVE to the status filter in GoDaddyProvider.cs so domains registered at a different registrar but with DNS hosted at GoDaddy are included in the zone listing  

## Validation

- [ ] `dotnet build -c Release ./src`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./src`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed

## Notes

- Domains with DNS hosted at GoDaddy but registered through another registrar (e.g., Network Solutions) report as `PENDING_DNS_ACTIVE` via the GoDaddy API. The DNS zone is fully operational, but the current `statuses=ACTIVE` filter excludes them from the zone listing dropdown.
