### PR TITLE
Update Bicep version to 0.42.1 and adjust package URI in deployment templates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOTNET_VERSION: 10.0.x
-  BICEP_VERSION: 0.40.2
+  BICEP_VERSION: 0.42.1
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   DOTNET_VERSION: 10.0.x
-  BICEP_VERSION: 0.40.2
+  BICEP_VERSION: 0.42.1
 
 jobs:
   publish:
@@ -43,7 +43,7 @@ jobs:
         name: dist
         path: |
           latest.zip
-          azuredeploy.bicep
+          deploy/azuredeploy.bicep
 
   deploy:
     runs-on: ubuntu-latest
@@ -72,10 +72,10 @@ jobs:
 
     - name: Upload to Blob
       run: |
-        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c keyvault-acmebot -n v${{ needs.publish.outputs.major_version }}/latest.zip --overwrite
-        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c keyvault-acmebot -n v${{ needs.publish.outputs.major_version }}/${{ needs.publish.outputs.version }}.zip --overwrite
+        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c acmebot -n v${{ needs.publish.outputs.major_version }}/latest.zip --overwrite
+        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c acmebot -n v${{ needs.publish.outputs.major_version }}/${{ needs.publish.outputs.version }}.zip --overwrite
 
     - name: Publish to Private Registry
       run: |
-        az bicep publish --file azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.major_version }} --force
-        az bicep publish --file azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/keyvault-acmebot:v${{ needs.publish.outputs.version }} --force
+        az bicep publish --file deploy/azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/acmebot:v${{ needs.publish.outputs.major_version }} --force
+        az bicep publish --file deploy/azuredeploy.bicep --target br:cracmebotprod.azurecr.io/bicep/modules/acmebot:v${{ needs.publish.outputs.version }} --force

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -191,7 +191,7 @@ resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
   parent: functionApp
   name: 'onedeploy'
   properties: {
-    packageUri: 'https://stacmebotprod.blob.core.windows.net/keyvault-acmebot/v5/latest.zip'
+    packageUri: 'https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip'
     remoteBuild: false
   }
 }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.40.2.10011",
-      "templateHash": "7664189418855377656"
+      "version": "0.42.1.51946",
+      "templateHash": "7098638128340013219"
     }
   },
   "parameters": {
@@ -227,7 +227,7 @@
       "apiVersion": "2025-03-01",
       "name": "[format('{0}/{1}', variables('functionAppName'), 'onedeploy')]",
       "properties": {
-        "packageUri": "https://stacmebotprod.blob.core.windows.net/keyvault-acmebot/v5/latest.zip",
+        "packageUri": "https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip",
         "remoteBuild": false
       },
       "dependsOn": [


### PR DESCRIPTION
This pull request updates the build and deployment workflows as well as deployment artifacts to use the latest Bicep version and to standardize naming and storage conventions from "keyvault-acmebot" to "acmebot". The changes also ensure that deployment references and publishing targets are consistent with the new naming scheme.

**Workflow and deployment updates:**

* Updated the Bicep version used in both `build.yml` and `publish.yml` workflows from `0.40.2` to `0.42.1` for improved compatibility and features. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R11) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L9-R9)
* Changed artifact and deployment paths in `publish.yml` to reference `deploy/azuredeploy.bicep` instead of the root-level file, and updated publishing targets to use the `acmebot` container and module names instead of `keyvault-acmebot`. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L46-R46) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L75-R81)

**Artifact and deployment reference updates:**

* Updated the deployment package URI in both `azuredeploy.bicep` and `azuredeploy.json` to use the `acmebot` container in blob storage instead of `keyvault-acmebot`. [[1]](diffhunk://#diff-f2ceaf2ff50b426e1177815f493418fa465b9944cea97319670e46a214d63328L194-R194) [[2]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL230-R230)
* Regenerated `azuredeploy.json` with the new Bicep version and updated template hash to reflect the changes.