### PR TITLE
Fix publish command to target the correct project directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         echo "MAJOR_VERSION=${FULL_VERSION%%.*}" >> $GITHUB_OUTPUT
 
     - name: Publish Function app
-      run: dotnet publish -c Release -r linux-x64 --no-self-contained -o ./dist -p:Version=${{ steps.setup_version.outputs.version }} ./src/Acmebot
+      run: dotnet publish -c Release --no-self-contained -o ./dist -p:Version=${{ steps.setup_version.outputs.version }} ./src/Acmebot.App
 
     - name: Zip Function app
       run: 7z a -mx=9 latest.zip ./dist/* ./dist/.[^.]*


### PR DESCRIPTION
This pull request updates the publish process in the GitHub Actions workflow to target the correct project for deployment.

- Workflow configuration update:
  * The `dotnet publish` command in `.github/workflows/publish.yml` now publishes the `Acmebot.App` project instead of the previous `Acmebot` project, ensuring the correct application is built and deployed.