### PR TITLE
Add ACME metadata tagging and HTTP client telemetry

### DIFF
--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="2.1.0-preview.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Acmebot.App.Models;
 
@@ -10,24 +12,32 @@ internal static class CertificateExtensions
 {
     public static bool IsIssuedByAcmebot(this CertificateProperties properties)
     {
-        return properties.Tags.TryGetIssuer(out var tagIssuer) && tagIssuer == IssuerValue;
+        if (properties.Tags.ContainsKey(AcmebotTagKey))
+        {
+            return true;
+        }
+
+        return properties.Tags.TryGetValue(LegacyIssuerKey, out var issuer) && issuer == IssuerValue;
     }
 
     public static bool IsSameEndpoint(this CertificateProperties properties, Uri endpoint)
     {
-        return properties.Tags.TryGetEndpoint(out var tagEndpoint) && NormalizeEndpoint(tagEndpoint) == endpoint.Host;
+        var metadata = properties.Tags.GetAcmebotMetadata();
+
+        return metadata is not null && !string.IsNullOrEmpty(metadata.Endpoint) && NormalizeEndpoint(metadata.Endpoint) == endpoint.Host;
     }
 
     public static CertificateItem ToCertificateItem(this KeyVaultCertificateWithPolicy certificate)
     {
         var dnsNames = certificate.Policy.SubjectAlternativeNames?.DnsNames.ToArray();
+        var metadata = certificate.Properties.Tags.GetAcmebotMetadata();
 
         return new CertificateItem
         {
             Id = certificate.Id,
             Name = certificate.Name,
             DnsNames = dnsNames is { Length: > 0 } ? dnsNames : [certificate.Policy.Subject[3..]],
-            DnsProviderName = certificate.Properties.Tags.TryGetDnsProvider(out var dnsProviderName) ? dnsProviderName : "",
+            DnsProviderName = metadata?.DnsProvider ?? "",
             CreatedOn = certificate.Properties.CreatedOn.GetValueOrDefault(DateTimeOffset.MinValue),
             ExpiresOn = certificate.Properties.ExpiresOn.GetValueOrDefault(DateTimeOffset.MaxValue),
             X509Thumbprint = Convert.ToHexString(certificate.Properties.X509Thumbprint),
@@ -36,59 +46,126 @@ internal static class CertificateExtensions
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
             ReuseKey = certificate.Policy.ReuseKey,
             IsExpired = DateTimeOffset.UtcNow > certificate.Properties.ExpiresOn.GetValueOrDefault(DateTimeOffset.MaxValue),
-            AcmeEndpoint = certificate.Properties.Tags.TryGetEndpoint(out var acmeEndpoint) ? NormalizeEndpoint(acmeEndpoint) : "",
-            DnsAlias = certificate.Properties.Tags.TryGetDnsAlias(out var dnsAlias) ? dnsAlias : ""
+            AcmeEndpoint = !string.IsNullOrEmpty(metadata?.Endpoint) ? NormalizeEndpoint(metadata.Endpoint) : "",
+            DnsAlias = metadata?.DnsAlias ?? ""
         };
     }
 
     public static CertificatePolicyItem ToCertificatePolicyItem(this KeyVaultCertificateWithPolicy certificate)
     {
         var dnsNames = certificate.Policy.SubjectAlternativeNames.DnsNames.ToArray();
+        var metadata = certificate.Properties.Tags.GetAcmebotMetadata();
 
         return new CertificatePolicyItem
         {
             CertificateName = certificate.Name,
             DnsNames = dnsNames.Length > 0 ? dnsNames : [certificate.Policy.Subject[3..]],
-            DnsProviderName = certificate.Properties.Tags.TryGetDnsProvider(out var dnsProviderName) ? dnsProviderName : "",
+            DnsProviderName = metadata?.DnsProvider ?? "",
             KeyType = certificate.Policy.KeyType.GetValueOrDefault(CertificateKeyType.Rsa).ToString(),
             KeySize = certificate.Policy.KeySize,
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
             ReuseKey = certificate.Policy.ReuseKey,
-            DnsAlias = certificate.Properties.Tags.TryGetDnsAlias(out var dnsAlias) ? dnsAlias : ""
+            DnsAlias = metadata?.DnsAlias ?? "",
+            CertificateId = metadata?.CertificateId
         };
     }
 
     public static IDictionary<string, string> ToCertificateMetadata(this CertificatePolicyItem certificatePolicyItem, Uri endpoint)
     {
-        var metadata = new Dictionary<string, string>
+        var metadata = new AcmebotCertificateMetadata
         {
-            { IssuerKey, IssuerValue },
-            { EndpointKey, endpoint.Host },
-            { DnsProviderKey, certificatePolicyItem.DnsProviderName ?? "" }
+            Endpoint = endpoint.Host,
+            DnsProvider = certificatePolicyItem.DnsProviderName ?? "",
+            DnsAlias = string.IsNullOrEmpty(certificatePolicyItem.DnsAlias) ? null : certificatePolicyItem.DnsAlias
         };
 
-        if (!string.IsNullOrEmpty(certificatePolicyItem.DnsAlias))
+        return new Dictionary<string, string>
         {
-            metadata.Add(DnsAliasKey, certificatePolicyItem.DnsAlias);
-        }
-
-        return metadata;
+            { AcmebotTagKey, JsonSerializer.Serialize(metadata, s_jsonOptions) }
+        };
     }
 
-    private const string IssuerKey = "Issuer";
-    private const string EndpointKey = "Endpoint";
-    private const string DnsProviderKey = "DnsProvider";
-    private const string DnsAliasKey = "DnsAlias";
+    public static void SetCertificateId(this IDictionary<string, string> tags, string certificateId)
+    {
+        ArgumentNullException.ThrowIfNull(tags);
+        ArgumentException.ThrowIfNullOrEmpty(certificateId);
+
+        var metadata = tags.GetAcmebotMetadata() ?? new AcmebotCertificateMetadata();
+
+        metadata.CertificateId = certificateId;
+
+        tags[AcmebotTagKey] = JsonSerializer.Serialize(metadata, s_jsonOptions);
+    }
+
+    public static bool TryGetCertificateId(this CertificateProperties properties, [NotNullWhen(true)] out string? certificateId)
+    {
+        var metadata = properties.Tags.GetAcmebotMetadata();
+
+        certificateId = metadata?.CertificateId;
+
+        return !string.IsNullOrEmpty(certificateId);
+    }
+
+    private const string AcmebotTagKey = "Acmebot";
+
+    // Legacy tag keys (kept for backward compatibility when reading existing certificates)
+    private const string LegacyIssuerKey = "Issuer";
+    private const string LegacyEndpointKey = "Endpoint";
+    private const string LegacyDnsProviderKey = "DnsProvider";
+    private const string LegacyDnsAliasKey = "DnsAlias";
 
     private const string IssuerValue = "Acmebot";
 
-    private static bool TryGetIssuer(this IDictionary<string, string> tags, [NotNullWhen(true)] out string? issuer) => tags.TryGetValue(IssuerKey, out issuer);
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
-    private static bool TryGetEndpoint(this IDictionary<string, string> tags, [NotNullWhen(true)] out string? endpoint) => tags.TryGetValue(EndpointKey, out endpoint);
+    private static AcmebotCertificateMetadata? GetAcmebotMetadata(this IDictionary<string, string> tags)
+    {
+        if (tags.TryGetValue(AcmebotTagKey, out var json) && !string.IsNullOrEmpty(json))
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<AcmebotCertificateMetadata>(json, s_jsonOptions);
+            }
+            catch (JsonException)
+            {
+                // Fall through to legacy tag parsing
+            }
+        }
 
-    private static bool TryGetDnsProvider(this IDictionary<string, string> tags, [NotNullWhen(true)] out string? dnsProviderName) => tags.TryGetValue(DnsProviderKey, out dnsProviderName);
+        if (tags.ContainsKey(LegacyIssuerKey))
+        {
+            tags.TryGetValue(LegacyEndpointKey, out var endpoint);
+            tags.TryGetValue(LegacyDnsProviderKey, out var dnsProvider);
+            tags.TryGetValue(LegacyDnsAliasKey, out var dnsAlias);
 
-    private static bool TryGetDnsAlias(this IDictionary<string, string> tags, [NotNullWhen(true)] out string? dnsAlias) => tags.TryGetValue(DnsAliasKey, out dnsAlias);
+            return new AcmebotCertificateMetadata
+            {
+                Endpoint = endpoint,
+                DnsProvider = dnsProvider,
+                DnsAlias = string.IsNullOrEmpty(dnsAlias) ? null : dnsAlias
+            };
+        }
+
+        return null;
+    }
 
     private static string NormalizeEndpoint(string endpoint) => Uri.TryCreate(endpoint, UriKind.Absolute, out var legacyEndpoint) ? legacyEndpoint.Host : endpoint;
+
+    private sealed class AcmebotCertificateMetadata
+    {
+        [JsonPropertyName("endpoint")]
+        public string? Endpoint { get; set; }
+
+        [JsonPropertyName("dnsProvider")]
+        public string? DnsProvider { get; set; }
+
+        [JsonPropertyName("dnsAlias")]
+        public string? DnsAlias { get; set; }
+
+        [JsonPropertyName("certificateId")]
+        public string? CertificateId { get; set; }
+    }
 }

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -26,8 +26,10 @@ public partial class AcmeOrderActivities(
     private readonly AcmebotOptions _options = options.Value;
 
     [Function(nameof(Order))]
-    public async Task<OrderDetails> Order([ActivityTrigger] IReadOnlyList<string> dnsNames)
+    public async Task<OrderDetails> Order([ActivityTrigger] (IReadOnlyList<string>, string?) input)
     {
+        var (dnsNames, replaces) = input;
+
         using var acmeContext = await acmeClientFactory.CreateClientAsync();
 
         var result = await acmeContext.Client.CreateOrderAsync(
@@ -37,7 +39,8 @@ public partial class AcmeOrderActivities(
                 Type = AcmeIdentifierTypes.Dns,
                 Value = x
             }).ToArray(),
-            profile: _options.PreferredProfile);
+            profile: _options.PreferredProfile,
+            replaces: replaces);
 
         return OrderDetails.FromResult(result);
     }
@@ -162,7 +165,16 @@ public partial class AcmeOrderActivities(
             [x509Certificates.Export(X509ContentType.Pfx)]
         );
 
-        return (await certificateClient.MergeCertificateAsync(mergeCertificateOptions)).Value.ToCertificateItem();
+        var mergedCertificate = (await certificateClient.MergeCertificateAsync(mergeCertificateOptions)).Value;
+
+        // ARI による更新判定に使う ACME Certificate Identifier (AKI + Serial) をタグに保存する
+        var certificateIdentifier = Acmebot.Acme.AcmeClient.CreateCertificateIdentifier(x509Certificates[0]);
+
+        mergedCertificate.Properties.Tags.SetCertificateId(certificateIdentifier);
+
+        await certificateClient.UpdateCertificatePropertiesAsync(mergedCertificate.Properties);
+
+        return mergedCertificate.ToCertificateItem();
     }
 
     [LoggerMessage(LogLevel.Error, "ACME domain validation failed. ProblemDetails: {ProblemDetailsJson}")]

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -26,8 +26,8 @@ public partial class CertificateIssuanceOrchestrator
             // 前提条件をチェック
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
-            // 新しく ACME Order を作成する
-            var orderDetails = await context.CallOrderAsync(certificatePolicyItem.DnsNames);
+            // 新しく ACME Order を作成する (ARI で更新扱いにする場合は既存証明書の Certificate ID を replaces に指定)
+            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId));
 
             // 既に確認済みの場合は Challenge をスキップする
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -33,6 +33,9 @@ public class CertificatePolicyItem : IValidatableObject
     [JsonProperty("dnsAlias")]
     public string? DnsAlias { get; set; }
 
+    [JsonProperty("certificateId")]
+    public string? CertificateId { get; set; }
+
     public IEnumerable<string> AliasedDnsNames => string.IsNullOrEmpty(DnsAlias) ? DnsNames : [DnsAlias];
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -21,12 +21,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication()
        .AddHttpApi();
 
 builder.Services.AddOpenTelemetry()
+       .WithMetrics(metrics => metrics.AddHttpClientInstrumentation())
+       .WithTracing(tracing => tracing.AddHttpClientInstrumentation())
        .UseFunctionsWorkerDefaults()
        .UseAzureMonitorExporter();
 


### PR DESCRIPTION
Add structured Acmebot certificate metadata and enable HTTP client OpenTelemetry instrumentation.

This change updates certificate tag handling so Acmebot metadata is stored as a single JSON payload, preserves backward compatibility for existing tags, and records the ACME certificate identifier needed for ARI-based renewal replacement flows. It also wires HTTP client metrics and tracing into the existing OpenTelemetry setup so outbound ACME and Azure calls are observable.

Validation:
- Built `src/Acmebot.App/Acmebot.App.csproj` successfully

Notable changes:
- store and read certificate metadata through the `Acmebot` tag
- persist `certificateId` after certificate merge and pass it into order creation as `replaces`
- add OpenTelemetry HTTP client instrumentation package and registration