### PR TITLE
Update package references for Acmebot.App and Acmebot.Acme.Tests projects

### DIFF
--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -12,25 +12,25 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Akamai.EdgeGrid.Auth" Version="1.0.0-preview" />
-    <PackageReference Include="AWSSDK.Route53" Version="4.0.8.20" />
+    <PackageReference Include="AWSSDK.Route53" Version="4.0.8.22" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />
     <PackageReference Include="Azure.ResourceManager.Dns" Version="1.1.1" />
-    <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.1" />
+    <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.9.0" />
     <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="Functions.Worker.Extensions.HttpApi" Version="3.0.5" />
     <PackageReference Include="Google.Apis.Dns.v1" Version="1.73.0.4109" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="2.1.0-preview.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Acmebot.Acme.Tests/Acmebot.Acme.Tests.csproj
+++ b/tests/Acmebot.Acme.Tests/Acmebot.Acme.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies to their latest versions in both the main application (`Acmebot.App`) and the test project (`Acmebot.Acme.Tests`). The updates focus on keeping the project current with security patches, bug fixes, and new features from upstream libraries.

Dependency updates:

* Updated several package references in `Acmebot.App.csproj`, including `AWSSDK.Route53`, `Azure.Monitor.OpenTelemetry.Exporter`, `Azure.ResourceManager.PrivateDns`, `Microsoft.Azure.Functions.Worker`, `Microsoft.Azure.Functions.Worker.Extensions.DurableTask`, `Microsoft.Azure.Functions.Worker.OpenTelemetry`, `OpenTelemetry.Extensions.Hosting`, and `OpenTelemetry.Instrumentation.Http` to their latest versions.

Test infrastructure:

* Updated `Microsoft.NET.Test.Sdk` to version `18.5.1` in `Acmebot.Acme.Tests.csproj` to ensure compatibility with the latest test runner features and bug fixes.